### PR TITLE
remove underlines from list item keys

### DIFF
--- a/backend/backend.containerfile
+++ b/backend/backend.containerfile
@@ -15,7 +15,7 @@ WORKDIR /backend
 
 EXPOSE 8000
 
-RUN dnf install -y pip
+RUN dnf install -y pip gcc python3-devel gcc-c++
 
 RUN pip install --user poetry && \
     poetry export -f requirements.txt -o requirements.txt && \

--- a/frontend/src/components/OCP/InstallCard.js
+++ b/frontend/src/components/OCP/InstallCard.js
@@ -44,13 +44,13 @@ export default function InstallCard(props) {
                     <GridItem rowSpan="1">
                         <Card><CardHeader><CardTitle>Cluster Metadata</CardTitle></CardHeader>
                             <CardBody><ul>
-                                <li><div class="list-item-key">Release Binary</div>: {config.cluster_version  && config.cluster_version || config.ocpVersion}</li>
-                                <li><div class="list-item-key">Cluster Name</div>: {config.cluster_name && config.cluster_name || config.clusterName}</li>
-                                <li><div class="list-item-key">Cluster Type</div>: {config.cluster_type  && config.cluster_type || config.clusterType}</li>
-                                <li><div class="list-item-key">Network Type</div>: {config.network_type  && config.network_type || config.networkType}</li>
-                                <li><div class="list-item-key">Benchmark Status</div>: {icons[config.job_status  && config.job_status || config.jobStatus] || config.job_status  && config.job_status || config.jobStatus}</li>
-                                <li><div class="list-item-key">Duration</div>: {formatTime(config.job_duration  && config.job_duration || config.jobDuration)}</li>
-                                <li><div class="list-item-key">Test ID</div>: {config.uuid}</li>
+                                <li><span class="list-item-key">Release Binary</span>: {config.cluster_version  && config.cluster_version || config.ocpVersion}</li>
+                                <li><span class="list-item-key">Cluster Name</span>: {config.cluster_name && config.cluster_name || config.clusterName}</li>
+                                <li><span class="list-item-key">Cluster Type</span>: {config.cluster_type  && config.cluster_type || config.clusterType}</li>
+                                <li><span class="list-item-key">Network Type</span>: {config.network_type  && config.network_type || config.networkType}</li>
+                                <li><span class="list-item-key">Benchmark Status</span>: {icons[config.job_status  && config.job_status || config.jobStatus] || config.job_status  && config.job_status || config.jobStatus}</li>
+                                <li><span class="list-item-key">Duration</span>: {formatTime(config.job_duration  && config.job_duration || config.jobDuration)}</li>
+                                <li><span class="list-item-key">Test ID</span>: {config.uuid}</li>
                             </ul>
 
                             </CardBody></Card></GridItem>
@@ -58,18 +58,18 @@ export default function InstallCard(props) {
                     <GridItem span="6">
                         <Card><CardHeader><CardTitle>Node Types</CardTitle></CardHeader>
                             <CardBody><ul>
-                                <li><div class="list-item-key">Master</div>: {config.master_type  && config.master_type || config.masterNodesType}</li>
-                                <li><div class="list-item-key">Worker</div>: {config.worker_type  && config.worker_type || config.workerNodesType}</li>
-                                <li><div class="list-item-key">Workload</div>: {config.workload_type && config.workload_type || config.benchmark}</li>
-                                <li><div class="list-item-key">Infra</div>: {config.infra_type  && config.infra_type || config.infraNodesType}</li>
+                                <li><span class="list-item-key">Master</span>: {config.master_type  && config.master_type || config.masterNodesType}</li>
+                                <li><span class="list-item-key">Worker</span>: {config.worker_type  && config.worker_type || config.workerNodesType}</li>
+                                <li><span class="list-item-key">Workload</span>: {config.workload_type && config.workload_type || config.benchmark}</li>
+                                <li><span class="list-item-key">Infra</span>: {config.infra_type  && config.infra_type || config.infraNodesType}</li>
                             </ul>
                             </CardBody></Card></GridItem><GridItem span="6">
                         <Card><CardHeader><CardTitle>Node Counts</CardTitle></CardHeader>
                             <CardBody><ul>
-                                <li><div class="list-item-key">Master</div>: {config.master_count  && config.master_count || config.masterNodesCount}</li>
-                                <li><div class="list-item-key">Worker</div>: {config.worker_count  && config.worker_count || config.workerNodesCount}</li>
-                                <li><div class="list-item-key">Infra</div>: {config.infra_count  && config.infra_count || config.infraNodesCount}</li>
-                                <li><div class="list-item-key">Total Nodes</div>: {config.workload_count  && config.workload_count || config.totalNodesCount}</li>
+                                <li><span class="list-item-key">Master</span>: {config.master_count  && config.master_count || config.masterNodesCount}</li>
+                                <li><span class="list-item-key">Worker</span>: {config.worker_count  && config.worker_count || config.workerNodesCount}</li>
+                                <li><span class="list-item-key">Infra</span>: {config.infra_count  && config.infra_count || config.infraNodesCount}</li>
+                                <li><span class="list-item-key">Total Nodes</span>: {config.workload_count  && config.workload_count || config.totalNodesCount}</li>
                             </ul>
                             </CardBody></Card>
                     </GridItem>

--- a/frontend/src/components/OCP/InstallCard.js
+++ b/frontend/src/components/OCP/InstallCard.js
@@ -44,13 +44,13 @@ export default function InstallCard(props) {
                     <GridItem rowSpan="1">
                         <Card><CardHeader><CardTitle>Cluster Metadata</CardTitle></CardHeader>
                             <CardBody><ul>
-                                <li><u>Release Binary</u>: {config.cluster_version  && config.cluster_version || config.ocpVersion}</li>
-                                <li><u>Cluster Name</u>: {config.cluster_name && config.cluster_name || config.clusterName}</li>
-                                <li><u>Cluster Type</u>: {config.cluster_type  && config.cluster_type || config.clusterType}</li>
-                                <li><u>Network Type</u>: {config.network_type  && config.network_type || config.networkType}</li>
-                                <li><u>Benchmark Status</u>: {icons[config.job_status  && config.job_status || config.jobStatus] || config.job_status  && config.job_status || config.jobStatus}</li>
-                                <li><u>Duration</u>: {formatTime(config.job_duration  && config.job_duration || config.jobDuration)}</li>
-                                <li><u>Test ID</u>: {config.uuid}</li>
+                                <li><div class="list-item-key">Release Binary</div>: {config.cluster_version  && config.cluster_version || config.ocpVersion}</li>
+                                <li><div class="list-item-key">Cluster Name</div>: {config.cluster_name && config.cluster_name || config.clusterName}</li>
+                                <li><div class="list-item-key">Cluster Type</div>: {config.cluster_type  && config.cluster_type || config.clusterType}</li>
+                                <li><div class="list-item-key">Network Type</div>: {config.network_type  && config.network_type || config.networkType}</li>
+                                <li><div class="list-item-key">Benchmark Status</div>: {icons[config.job_status  && config.job_status || config.jobStatus] || config.job_status  && config.job_status || config.jobStatus}</li>
+                                <li><div class="list-item-key">Duration</div>: {formatTime(config.job_duration  && config.job_duration || config.jobDuration)}</li>
+                                <li><div class="list-item-key">Test ID</div>: {config.uuid}</li>
                             </ul>
 
                             </CardBody></Card></GridItem>
@@ -58,18 +58,18 @@ export default function InstallCard(props) {
                     <GridItem span="6">
                         <Card><CardHeader><CardTitle>Node Types</CardTitle></CardHeader>
                             <CardBody><ul>
-                                <li><u>Master</u>: {config.master_type  && config.master_type || config.masterNodesType}</li>
-                                <li><u>Worker</u>: {config.worker_type  && config.worker_type || config.workerNodesType}</li>
-                                <li><u>Workload</u>: {config.workload_type && config.workload_type || config.benchmark}</li>
-                                <li><u>Infra</u>: {config.infra_type  && config.infra_type || config.infraNodesType}</li>
+                                <li><div class="list-item-key">Master</div>: {config.master_type  && config.master_type || config.masterNodesType}</li>
+                                <li><div class="list-item-key">Worker</div>: {config.worker_type  && config.worker_type || config.workerNodesType}</li>
+                                <li><div class="list-item-key">Workload</div>: {config.workload_type && config.workload_type || config.benchmark}</li>
+                                <li><div class="list-item-key">Infra</div>: {config.infra_type  && config.infra_type || config.infraNodesType}</li>
                             </ul>
                             </CardBody></Card></GridItem><GridItem span="6">
                         <Card><CardHeader><CardTitle>Node Counts</CardTitle></CardHeader>
                             <CardBody><ul>
-                                <li><u>Master</u>: {config.master_count  && config.master_count || config.masterNodesCount}</li>
-                                <li><u>Worker</u>: {config.worker_count  && config.worker_count || config.workerNodesCount}</li>
-                                <li><u>Infra</u>: {config.infra_count  && config.infra_count || config.infraNodesCount}</li>
-                                <li><u>Total Nodes</u>: {config.workload_count  && config.workload_count || config.totalNodesCount}</li>
+                                <li><div class="list-item-key">Master</div>: {config.master_count  && config.master_count || config.masterNodesCount}</li>
+                                <li><div class="list-item-key">Worker</div>: {config.worker_count  && config.worker_count || config.workerNodesCount}</li>
+                                <li><div class="list-item-key">Infra</div>: {config.infra_count  && config.infra_count || config.infraNodesCount}</li>
+                                <li><div class="list-item-key">Total Nodes</div>: {config.workload_count  && config.workload_count || config.totalNodesCount}</li>
                             </ul>
                             </CardBody></Card>
                     </GridItem>

--- a/frontend/src/components/css/PlatformView.css
+++ b/frontend/src/components/css/PlatformView.css
@@ -7,3 +7,6 @@
   color: #61dafb;
 }
 
+.list-item-key {
+  font-weight: bold;
+}


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Underlines are confusing in a web interface where they normally imply a hyperlink. Replace the `<u>` tags around the keys in `<li>` items with `<div>` with style references using bold formatting instead.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
I tried to quickly get the yarn environment running for local frontend testing, but it wouldn't work for me and for this simple style change I didn't invest the time to troubleshoot the test environment. I would appreciate it if someone else could validate this real quick.