### PR TITLE
Updating actions to get triggered only on main branch

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -1,5 +1,8 @@
 name: Build and Push Image
-on: [ push ]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/release-build-push.yaml
+++ b/.github/workflows/release-build-push.yaml
@@ -3,7 +3,9 @@ name: Release Build and Push Image
 on:
   push:
     tags:
-      - "*" 
+      - "*"
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Making code changes to trigger github actions only on the main branch.

## Related Tickets & Documents
At present we have github actions being triggered for every single push, which lead changes in `revamp` branch go into dev, breaking the dashboard
```
# ls
README.md  frontend.containerfile  index.html  jsconfig.json  node_modules  package-lock.json  package.json  public  src  vite.config.js
```
And this was the action responsible for it: https://github.com/cloud-bulldozer/cpt-dashboard/actions/runs/9953308824/job/27496484697

potential solution is to update this [workflow file](https://github.com/cloud-bulldozer/cpt-dashboard/blob/main/.github/workflows/build-push.yaml) to only publish images on target branch main not for others which happened to be revamp as the latest from the action above.
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Needs this PR to be merged in order to see if it works with github actions runner.
