### PR TITLE
Crucible service unit test coverage

### DIFF
--- a/.github/codeql/javascript-config.yml
+++ b/.github/codeql/javascript-config.yml
@@ -1,0 +1,4 @@
+name: "CodeQL config for Javascript"
+
+paths:
+  - frontend/src/**

--- a/.github/codeql/python-config.yml
+++ b/.github/codeql/python-config.yml
@@ -1,0 +1,1 @@
+name: "CodeQL config for Python"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,58 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ main, 'b[0-9].[0-9]+' ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main, 'b[0-9].[0-9]+' ]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript', 'python' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        config-file: ./.github/codeql/${{ matrix.language }}-config.yml
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    #- name: Autobuild
+    #  uses: github/codeql-action/autobuild@v2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/poetry-check.yaml
+++ b/.github/workflows/poetry-check.yaml
@@ -15,6 +15,6 @@ jobs:
         - name: verify poetry instalation
           run: poetry --version
           working-directory: ./backend
-        - name: verify poetry lockfile
-          run: poetry check --lock
+        - name: verify poetry configuration
+          run: poetry check
           working-directory: ./backend

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,47 @@
+name: Python checks
+
+on:
+    push:
+        branches: ["main"]
+        tags-ignore: ["**"]
+    pull_request:
+
+env:
+    COVERAGE: ${{ github.workspace }}/coverage
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9.20"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox>=4.19
+      - name: Check for lint
+        # Report errors but don't fail until we achieve stability!
+        continue-on-error: true
+        run: |
+          cd backend
+          tox -e format,isort,lint
+      - name: Run unit tests
+        run: |
+          cd backend
+          tox -e unit
+      - name: Add coverage data to conversation
+        run: cat $COVERAGE/coverage.txt >> $GITHUB_STEP_SUMMARY
+      - name: Publish coverage data
+        uses: actions/upload-artifact@v4
+        with:
+            name: Coverage for ${{ github.event.head_commit.id }}
+            path: ${{ env.COVERAGE }}/html
+            if-no-files-found: warn
+            retention-days: 30

--- a/backend/app/services/crucible_readme.md
+++ b/backend/app/services/crucible_readme.md
@@ -1,0 +1,164 @@
+Crucible divides data across a set of OpenSearch (or ElasticSearch) indices,
+each with a specific document mapping. CDM index names include a "root" name
+(like "run") with a versioned prefix, like "cdmv7dev-run".
+
+Crucible timestamps are integers in "millisecond-from-the-epoch" format.
+
+The Crucible CDM hierarchy is roughly:
+
+- RUN (an instrumented benchmark run)
+  - TAG (metadata)
+  - ITERATION (a benchmark interval)
+    - PARAM (execution parameters)
+    - SAMPLE
+      - PERIOD (time range where data is recorded)
+        - METRIC_DESC (description of a specific recorded metric)
+          - METRIC_DATA (a specific recorded data point)
+
+OpenSearch doesn't support the concept of a SQL "join", but many of the indices
+contain documents that could be considered a static "join" with parent documents
+for convenience. For example, each `iteration` document contains a copy of it's
+parent `run` document, while the `period` document contains copies of its parent
+`sample`, `iteration`, and `run` documents. This means, for example, that it's
+possible to make a single query returning all `period` documents for specific
+iteration number of a specific run.
+
+<dl>
+<dt>RUN</dt><dd>this contains the basic information about a performance run, including a
+    generated UUID, begin and end timestamps, a benchmark name, a user name and
+    email, the (host/directory) "source" of the indexed data (which is usable on
+    the controler's local file system), plus host and test harness names.</dd>
+<dt>TAG</dt><dd>this contains information about a general purpose "tag" to associate some
+    arbitrary context with a run, for example software versions, hardware, or
+    other metadata. This can be considered a SQL JOIN with the run document,
+    adding a tag UUID, name, and value.</dd>
+<dt>ITERATION</dt><dd>this contains basic information about a performance run iteration,
+    including the iteration UUID, number, the primary (benchmark) metric associated
+    with the iteration, plus the primary "period" of the iteration, and the
+    iteration status.</dd>
+<dt>PARAM</dt><dd>this defines a key/value pair specifying behavior of the benchmark
+    script for an iteration. Parameters are iteration-specific, but parameters that
+    don't vary between iterations are often represented as run parameters.</dd>
+<dt>SAMPLE</dt><dd>this contains basic information about a sample of an iteration,
+    including a sample UUID and sample number, along with a "path" for sample data
+    and a sample status.</dd>
+<dt>PERIOD</dt><dd>this contains basic information about a period during which data is
+    collected within a sample, including the period UUID, name, and begin and end
+    timestamps. A set of periods can be "linked" through a "prev_id" field.</dd>
+<dt>METRIC_DESC</dt><dd>this contains descriptive data about a specific series
+    of metric values within a specific period of a run, including the metric UUID,
+    the metric "class", type, and source, along with a set of "names" (key/value
+    pairs) defining the metric breakout details that narrow down a specific source and
+    type. For example source:mpstat, type:Busy-CPU data is broken down by package, cpu,
+    core, and other breakouts which can be isolated or aggregated for data reporting.</dd>
+<dt>METRIC_DATA</dt><dd>this describes a specific data point, sampled over a specified
+    duration with a fixed begin and end timestamp, plus a floating point value.
+    Each is tied to a specific metric_desc UUID value. Depending on the varied
+    semantics of metric_desc breakouts, it's often valid to aggregate these
+    across a set of relatead metric_desc IDs, based on source and type, for
+    example to get aggregate CPU load across all modes, cores, or across all
+    modes within a core. This service allows arbitrary aggregation within a
+    given metric source and type, but by default will attempt to direct the
+    caller to specifying a set of breakouts that result in a single metric_desc
+    ID.</dd>
+</dl>
+
+The `crucible_svc` allows CPT project APIs to access a Crucible CDM backing
+store to find information about runs, tags, params, iterations, samples,
+periods, plus various ways to expose and aggregate metric data both for
+primary benchmarks and non-periodic tools.
+
+The `get_runs` API is the primary entry point, returning an object that
+supports filtering, sorting, and pagination of the Crucible run data decorated
+with useful iteration, tag, and parameter data.
+
+The metrics data APIs (data, breakouts, summary, and graph) now allow
+filtering by the metric "name" data. This allows "drilling down" through
+the non-periodic "tool data". For example, IO data is per-disk, CPU
+information is broken down by core and package. You can now aggregate
+all global data (e.g., total system CPU), or filter by breakout names to
+select by CPU, mode (usr, sys, irq), etc.
+
+For example, to return `Busy-CPU` ("type") graph data from the `mpstat`
+("source") tool for system mode on one core, you might query:
+
+```
+/api/v1/ilab/runs/<id>/graph/mpstat::Busy-CPU?name=core=12,package=1,num=77,type=sys
+```
+
+If you make a `graph`, `data`, or `summary` query that doesn't translate
+to a unique metric, and don't select aggregation, you'll get a diagnostic
+message identifying possible additional filters. For example, with
+`type=sys` removed, that same query will show the available values for
+the `type` breakout name:
+
+```
+{
+  "detail": [
+    {
+      "message": "More than one metric (5) probably means you should add filters",
+      "names": {
+        "type": [
+          "guest",
+          "irq",
+          "soft",
+          "sys",
+          "usr"
+        ]
+      },
+      "periods": []
+    }
+  ]
+}
+```
+
+This capability can be used to build an interactive exploratory UI to
+allow displaying breakout details. The `get_metrics` API will show all
+recorded metrics, along with information the names and values used in
+those. Metrics that show "names" with more than one value will need to be
+filtered to produce meaningful summaries or graphs.
+
+You can instead aggregate metrics across breakouts using the `?aggregate`
+query parameter, like `GET /api/v1/ilab/runs/<id>/graph/mpstat::Busy-CPU?aggregate`
+which will aggregate all CPU busy data for the system.
+
+Normally you'll want to display data based on sample periods, for example the
+primary period of an iteration, using `?period=<period-id>`. This will
+implicitly constrain the metric data based on the period ID associated with
+the `metric_desc` document *and* the begin/end time period of the selected
+periods. Normally, a benchmark will will separate iterations because each is
+run with a different parameter value, and the default graph labeling will
+look for a set of distinct parameters not used by other iterations: for
+example, `mpstat::Busy-CPU (batch-size=16)`.
+
+The `get_breakouts` API can be used to explore the namespace recorded for that
+metric in the specified run. For example,
+
+```
+GET /api/v1/ilab/runs/<id>/breakouts/sar-net::packets-sec?name=direction=rx
+{
+  "label": "sar-net::packets-sec",
+  "source": "sar-net",
+  "type": "packets-sec",
+  "class": [],
+  "names": {
+    "dev": [
+      "lo",
+      "eno12409",
+      "eno12399"
+    ],
+    "type": [
+      "physical",
+      "virtual"
+    ]
+  }
+}
+```
+
+The `get_filters` API reports all the tag and param filter tags and
+values for the runs. These can be used for the `filters` query parameter
+on `get_runs` to restrict the set of runs reported; for example,
+`/api/v1/ilab/runs?filter=param:workflow=sdg` shows only runs with the param
+arg `workflow` set to the value `sdg`. You can search for a subset of the
+string value using the operator "~" instead of "=". For example,
+`?filter=param:user~user` will match `user` values of "A user" or "The user".

--- a/backend/app/services/crucible_svc.py
+++ b/backend/app/services/crucible_svc.py
@@ -1,0 +1,1988 @@
+"""Service to pull data from a Crucible CDM OpenSearch data store
+
+A set of helper methods to enable a project API to easily process data from a
+Crucible controller's OpenSearch data backend.
+
+This includes paginated, filtered, and sorted lists of benchmark runs, along
+access to the associated Crucible documents such as iterations, samples, and
+periods. Metric data can be accessed by breakout names, or aggregated by
+breakout subsets or collection periods as either raw data points, statistical
+aggregate, or Plotly graph format for UI display.
+"""
+
+import time
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterator, Optional, Tuple, Union
+
+from elasticsearch import AsyncElasticsearch, NotFoundError
+from fastapi import HTTPException, status
+from pydantic import BaseModel
+
+from app import config
+
+
+class Graph(BaseModel):
+    """Describe a single graph
+
+    This represents a JSON object provided by a caller through the get_graph
+    API to describe a specific metric graph.
+
+    The default title (if the field is omitted) is the metric label with a
+    suffix denoting breakout values selected, any unique parameter values
+    in a selected iteration, and (if multiple runs are selected in any Graph
+    list) an indication of the run index. For example,
+    "mpstat::Busy-CPU [core=2,type=usr] (batch-size=16)".
+
+    Fields:
+        metric: the metric label, "ilab::train-samples-sec"
+        aggregate: True to aggregate unspecified breakouts
+        color: CSS color string ("green" or "#008000")
+        names: Lock in breakouts
+        periods: Select metrics for specific test period(s)
+        run: Override the default run ID from GraphList
+        title: Provide a title for the graph. The default is a generated title
+    """
+
+    metric: str
+    aggregate: bool = False
+    color: Optional[str] = None
+    names: Optional[list[str]] = None
+    periods: Optional[list[str]] = None
+    run: Optional[str] = None
+    title: Optional[str] = None
+
+
+class GraphList(BaseModel):
+    """Describe a set of overlaid graphs
+
+    This represents a JSON object provided by a caller through the get_graph
+    API to introduce a set of constrained metrics to be graphed. The "run
+    ID" here provides a default for the embedded Graph objects, and can be
+    omitted if all Graph objects specify a run ID. (This is most useful to
+    select a set of graphs all for a single run ID.)
+
+    Fields:
+        run: Specify the (default) run ID
+        name: Specify a name for the set of graphs
+        graphs: a list of Graph objects
+    """
+
+    run: Optional[str] = None
+    name: str
+    graphs: list[Graph]
+
+
+@dataclass
+class Point:
+    """Graph point
+
+    Record the start & end timestamp and value of a metric data point
+    """
+
+    begin: int
+    end: int
+    value: float
+
+
+colors = [
+    "black",
+    "aqua",
+    "blue",
+    "fuschia",
+    "gray",
+    "green",
+    "maroon",
+    "navy",
+    "olive",
+    "teal",
+    "silver",
+    "lightskyblue",
+    "mediumspringgreen",
+    "mistyrose",
+    "darkgoldenrod",
+    "cadetblue",
+    "chocolate",
+    "coral",
+    "brown",
+    "bisque",
+    "deeppink",
+    "sienna",
+]
+
+
+@dataclass
+class Term:
+    namespace: str
+    key: str
+    value: str
+
+
+class Parser:
+    """Help parsing filter expressions."""
+
+    def __init__(self, term: str):
+        """Construct an instance to help parse query parameter expressions
+
+        These consist of a sequence of tokens separated by delimiters. Each
+        token may be quoted to allow matching against strings with spaces.
+
+        For example, `param:name="A string"`
+
+        Args:
+            term: A filter expression to parse
+        """
+        self.buffer = term
+        self.context = term
+        self.offset = 0
+
+    def _next_token(
+        self, delimiters: list[str] = [], optional: bool = False
+    ) -> Tuple[str, Union[str, None]]:
+        """Extract the next token from an expression
+
+        Tokens may be quoted; the quotes are removed. for example, the two
+        expressions `'param':"workflow"='"sdg"'` and `param:workflow:sdg` are
+        identical.
+
+        Args:
+            delimiters: a list of delimiter characters
+            optional: whether the terminating delimiter is optional
+
+        Returns:
+            A tuple consisting of the token and the delimiter (or None if
+            parsing reached the end of the expression and the delimiter was
+            optional)
+        """
+
+        @dataclass
+        class Quote:
+            open: int
+            quote: str
+
+        quoted: list[Quote] = []
+        next_char = None
+        token = ""
+        first_quote = None
+        for o in range(len(self.buffer)):
+            next_char = self.buffer[o]
+            if next_char in delimiters and not quoted:
+                self.buffer = self.buffer[o + 1 :]
+                self.offset += o + 1
+                break
+            elif next_char in ('"', "'"):
+                if o == 0:
+                    first_quote = next_char
+                if quoted and quoted[-1].quote == next_char:
+                    quoted.pop()
+                else:
+                    quoted.append(Quote(o, next_char))
+            token += next_char
+        else:
+            next_char = None
+            if quoted:
+                q = quoted[-1]
+                c = self.context
+                i = q.open + self.offset
+                annotated = c[:i] + "[" + c[i] + "]" + c[i + 1 :]
+                raise HTTPException(
+                    status.HTTP_400_BAD_REQUEST, f"Unterminated quote at {annotated!r}"
+                )
+
+            # If delimiters are specified, and not optional, then we didn't
+            # find one, and that's an error.
+            if not optional and delimiters:
+                raise HTTPException(
+                    status.HTTP_400_BAD_REQUEST,
+                    f"Missing delimiter from {','.join(delimiters)} after {token!r}",
+                )
+            self.buffer = ""
+            self.offset = len(self.context)
+        return (token, next_char) if not first_quote else (token[1:-1], next_char)
+
+
+class CommonParams:
+    """Help with sorting out parameters
+
+    Parameter values are associated with iterations, but often a set of
+    parameters is common across all iterations of a run, and that set can
+    provide useful context.
+
+    This helps to filter out identical parameters across a set of
+    iterations.
+    """
+
+    def __init__(self):
+        self.common: dict[str, Any] = {}
+        self.omit = set()
+
+    def add(self, params: dict[str, Any]):
+        """Add a new iteration into the param set
+
+        Mark all parameter keys which don't appear in all iterations, or which
+        have different values in at least one iteration, to be omitted from the
+        merged "common" param set.
+
+        Args:
+            params: the param dictionary of an iteration
+        """
+        if not self.common:
+            self.common.update(params)
+        else:
+            for k, v in self.common.items():
+                if k not in self.omit and (k not in params or v != params[k]):
+                    self.omit.add(k)
+
+    def render(self) -> dict[str, Any]:
+        """Return a new param set with only common params"""
+        return {k: v for k, v in self.common.items() if k not in self.omit}
+
+
+class CrucibleService:
+    """Support convenient generalized access to Crucible data
+
+    This implements access to the "v7" Crucible "Common Data Model" through
+    OpenSearch queries.
+    """
+
+    # OpenSearch massive limit on hits in a single query
+    BIGQUERY = 262144
+
+    # Define the 'run' document fields that support general filtering via
+    # `?filter=<name>:<value>`
+    #
+    # TODO: this excludes 'desc', which isn't used by the ilab runs, and needs
+    # different treatment as it's a text field rather than a term. It's not an
+    # immediate priority for ilab, but may be important for general use.
+    RUN_FILTERS = ("benchmark", "email", "name", "source", "harness", "host")
+
+    # Define the keywords for sorting.
+    DIRECTIONS = ("asc", "desc")
+    FIELDS = (
+        "begin",
+        "benchmark",
+        "desc",
+        "email",
+        "end",
+        "harness",
+        "host",
+        "id",
+        "name",
+        "source",
+    )
+
+    def __init__(self, configpath: str = "crucible"):
+        """Initialize a Crucible CDM (OpenSearch) connection.
+
+        Generally the `configpath` should be scoped, like `ilab.crucible` so
+        that multiple APIs based on access to distinct Crucible controllers can
+        coexist.
+
+        Initialization includes making an "info" call to confirm and record the
+        server response.
+
+        Args:
+            configpath: The Vyper config path (e.g., "ilab.crucible")
+        """
+        self.cfg = config.get_config()
+        self.user = self.cfg.get(configpath + ".username")
+        self.password = self.cfg.get(configpath + ".password")
+        self.auth = (self.user, self.password) if self.user or self.password else None
+        self.url = self.cfg.get(configpath + ".url")
+        self.elastic = AsyncElasticsearch(self.url, basic_auth=self.auth)
+
+    @staticmethod
+    def _get_index(root: str) -> str:
+        return "cdmv7dev-" + root
+
+    @staticmethod
+    def _split_list(alist: Optional[list[str]] = None) -> list[str]:
+        """Split a list of parameters
+
+        For simplicity, the APIs supporting "list" query parameters allow
+        each element in the list to be a comma-separated list of strings.
+        For example, ["a", "b", "c"] is logically the same as ["a,b,c"].
+
+        This method normalizes the second form into first to simplify life for
+        consumers.
+
+        Args:
+            alist: list of names or name lists
+
+        Returns:
+            A simple list of options
+        """
+        l: list[str] = []
+        if alist:
+            for n in alist:
+                l.extend(n.split(","))
+        return l
+
+    @staticmethod
+    def _normalize_date(value: Optional[Union[int, str, datetime]]) -> int:
+        """Normalize date parameters
+
+        The Crucible data model stores dates as string representations of an
+        integer "millseconds-from-epoch" value. To allow flexibility, this
+        Crucible service allows incoming dates to be specified as ISO-format
+        strings, as integers, or as the stringified integer.
+
+        That is, "2024-09-12 18:29:35.123000+00:00", "1726165775123", and
+        1726165775123 are identical.
+
+        Args:
+            value: Representation of a date-time value
+
+        Returns:
+            The integer milliseconds-from-epoch equivalent
+        """
+        try:
+            if isinstance(value, int):
+                return value
+            elif isinstance(value, datetime):
+                return int(value.timestamp() * 1000.0)
+            elif isinstance(value, str):
+                try:
+                    return int(value)
+                except ValueError:
+                    pass
+                try:
+                    d = datetime.fromisoformat(value)
+                    return int(d.timestamp() * 1000.0)
+                except ValueError:
+                    pass
+        except Exception as e:
+            print(f"normalizing {type(value).__name__} {value} failed with {str(e)}")
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                f"Date representation {value} is not a date string or timestamp",
+            )
+
+    @staticmethod
+    def _hits(
+        payload: dict[str, Any], fields: Optional[list[str]] = None
+    ) -> Iterator[dict[str, Any]]:
+        """Helper to iterate through OpenSearch query matches
+
+        Iteratively yields the "_source" of each hit. As a convenience, can
+        yield a sub-object of "_source" ... for example, specifying the
+        optional "fields" as ["metric_desc", "id"] will yield the equivalent of
+        hit["_source"]["metric_desc"]["id"]
+
+        Args:
+            payload: OpenSearch reponse payload
+            fields: Optional sub-fields of "_source"
+
+        Returns:
+            Yields each object from the "greatest hits" list
+        """
+        if "hits" not in payload:
+            raise HTTPException(
+                status_code=500, detail=f"Attempt to iterate hits for {payload}"
+            )
+        hits = payload.get("hits", {}).get("hits", [])
+        for h in hits:
+            source = h["_source"]
+            if fields:
+                for f in fields:
+                    source = source[f]
+            yield source
+
+    @staticmethod
+    def _aggs(payload: dict[str, Any], aggregation: str) -> Iterator[dict[str, Any]]:
+        """Helper to access OpenSearch aggregations
+
+        Iteratively yields the name and value of each aggregation returned
+        by an OpenSearch query. This can also be used for nested aggregations
+        by specifying an aggregation object.
+
+        Args:
+            payload: A JSON dict containing an "aggregations" field
+
+        Returns:
+            Yields each aggregation from an aggregation bucket list
+        """
+        if "aggregations" not in payload:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Attempt to iterate missing aggregations for {payload}",
+            )
+        aggs = payload["aggregations"]
+        if aggregation not in aggs:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Attempt to iterate missing aggregation {aggregation} for {payload}",
+            )
+        for agg in aggs[aggregation]["buckets"]:
+            yield agg
+
+    @staticmethod
+    def _format_timestamp(timestamp: Union[str, int]) -> str:
+        """Convert stringified integer milliseconds-from-epoch to ISO date"""
+        try:
+            ts = int(timestamp)
+        except Exception as e:
+            print(f"ERROR: invalid {timestamp!r}: {str(e)!r}")
+            ts = 0
+        return str(datetime.fromtimestamp(ts / 1000.00, timezone.utc))
+
+    @classmethod
+    def _format_data(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Helper to format a "metric_data" object
+
+        Crucible stores the date, duration, and value as strings, so this
+        converts them to more useful values. The end timestamp is converted
+        to an ISO date-time string; the duration and value to floating point
+        numbers.
+
+        Args:
+            data: a "metric_data" object
+
+        Returns:
+            A neatly formatted "metric_data" object
+        """
+        return {
+            "begin": cls._format_timestamp(data["begin"]),
+            "end": cls._format_timestamp(data["end"]),
+            "duration": int(data["duration"]) / 1000,
+            "value": float(data["value"]),
+        }
+
+    @classmethod
+    def _format_period(cls, period: dict[str, Any]) -> dict[str, Any]:
+        """Helper to format a "period" object
+
+        Crucible stores the date values as stringified integers, so this
+        converts the begin and end timestamps to ISO date-time strings.
+
+        Args:
+            period: a "period" object
+
+        Returns:
+            A neatly formatted "period" object
+        """
+        return {
+            "begin": cls._format_timestamp(timestamp=period["begin"]),
+            "end": cls._format_timestamp(period["end"]),
+            "id": period["id"],
+            "name": period["name"],
+        }
+
+    @classmethod
+    def _build_filter_options(cls, filter: Optional[list[str]] = None) -> Tuple[
+        Optional[list[dict[str, Any]]],
+        Optional[list[dict[str, Any]]],
+        Optional[list[dict[str, Any]]],
+    ]:
+        """Build filter terms for tag and parameter filter terms
+
+        Each term has the form "<namespace>:<key><operator><value>". Any term
+        may be quoted: quotes are stripped and ignored. (This is generally only
+        useful on the <value> to include spaces.)
+
+        We support three namespaces:
+            param: Match against param index arg/val
+            tag: Match against tag index name/val
+            run: Match against run index fields
+
+        We support two operators:
+            =: Exact match
+            ~: Partial match
+
+        Args:
+            filter: list of filter terms like "param:key=value"
+
+        Returns:
+            A set of OpenSearch filter object lists to detect missing
+            and matching documents for params, tags, and run fields. For
+            example, to select param:batch-size=12 results in the
+            following param filter list:
+
+                [
+                    {'
+                        dis_max': {
+                            'queries': [
+                                {
+                                    'bool': {
+                                        'must': [
+                                            {'term': {'param.arg': 'batch-size'}},
+                                            {'term': {'param.val': '12'}}
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+        """
+        terms = defaultdict(list)
+        for term in cls._split_list(filter):
+            p = Parser(term)
+            namespace, _ = p._next_token([":"])
+            key, operation = p._next_token(["=", "~"])
+            value, _ = p._next_token()
+            if operation == "~":
+                value = f".*{value}.*"
+                matcher = "regexp"
+            else:
+                matcher = "term"
+            if namespace in ("param", "tag"):
+                if namespace == "param":
+                    key_field = "param.arg"
+                    value_field = "param.val"
+                else:
+                    key_field = "tag.name"
+                    value_field = "tag.val"
+                terms[namespace].append(
+                    {
+                        "bool": {
+                            "must": [
+                                {"term": {key_field: key}},
+                                {matcher: {value_field: value}},
+                            ]
+                        }
+                    }
+                )
+            elif namespace == "run":
+                terms[namespace].append({matcher: {f"run.{key}": value}})
+            else:
+                raise HTTPException(
+                    status.HTTP_400_BAD_REQUEST,
+                    f"unknown filter namespace {namespace!r}",
+                )
+        param_filter = None
+        tag_filter = None
+        if "param" in terms:
+            param_filter = [{"dis_max": {"queries": terms["param"]}}]
+        if "tag" in terms:
+            tag_filter = [{"dis_max": {"queries": terms["tag"]}}]
+        return param_filter, tag_filter, terms.get("run")
+
+    @classmethod
+    def _build_name_filters(
+        cls, namelist: Optional[list[str]] = None
+    ) -> list[dict[str, Any]]:
+        """Build filter terms for metric breakout names
+
+        for example, "cpu=10" filters for metric data descriptors where the
+        breakout name "cpu" exists and has a value of 10.
+
+        Args:
+            namelist: list of possibly comma-separated list values
+
+        Returns:
+            A list of filters to match breakout terms
+        """
+        names: list[str] = cls._split_list(namelist)
+        filters = []
+        for e in names:
+            try:
+                n, v = e.split("=", maxsplit=1)
+            except ValueError:
+                raise HTTPException(
+                    status.HTTP_400_BAD_REQUEST, f"Filter item {e} must be '<k>=<v>'"
+                )
+            filters.append({"term": {f"metric_desc.names.{n}": v}})
+        return filters
+
+    @classmethod
+    def _build_period_filters(
+        cls, periodlist: Optional[list[str]] = None
+    ) -> list[dict[str, Any]]:
+        """Build period filters
+
+        Generate metric_desc filter terms to match against a list of period IDs.
+
+        Note that not all metric descriptions are periodic, and we don't want
+        these filters to exclude them -- so the filter will exclude only
+        documents that have a period and don't match. (That is, we won't drop
+        any non-periodic metrics. We expect those to be filtered by timestamp
+        instead.)
+
+        Args:
+            period: list of possibly comma-separated period IDs
+
+        Returns:
+            A filter term that requires a period.id match only for metric_desc
+            documents with a period.
+        """
+        pl: list[str] = cls._split_list(periodlist)
+        if pl:
+            return [
+                {
+                    "dis_max": {
+                        "queries": [
+                            {"bool": {"must_not": {"exists": {"field": "period"}}}},
+                            {"terms": {"period.id": pl}},
+                        ]
+                    }
+                }
+            ]
+        else:
+            return []
+
+    @classmethod
+    def _build_metric_filters(
+        cls,
+        run: str,
+        metric: str,
+        names: Optional[list[str]] = None,
+        periods: Optional[list[str]] = None,
+    ) -> list[dict[str, Any]]:
+        """Helper for filtering metric descriptions
+
+        We normally filter by run, metric "label", and optionally by breakout
+        names and periods. This encapsulates the filter construction.
+
+        Args:
+            run: run ID
+            metric: metric label (ilab::sdg-samples-sec)
+            names: list of "name=value" filters
+            periods: list of period IDs
+
+        Returns:
+            A list of OpenSearch filter expressions
+        """
+        msource, mtype = metric.split("::")
+        return (
+            [
+                {"term": {"run.id": run}},
+                {"term": {"metric_desc.source": msource}},
+                {"term": {"metric_desc.type": mtype}},
+            ]
+            + cls._build_name_filters(names)
+            + cls._build_period_filters(periods)
+        )
+
+    @classmethod
+    def _build_sort_terms(cls, sorters: Optional[list[str]]) -> list[dict[str, str]]:
+        """Build sort term list
+
+        Sorters may reference any native `run` index field and must specify
+        either "asc"(ending) or "desc"(ending) sort order. Any number of
+        sorters may be combined, like ["name:asc,benchmark:desc", "end:desc"]
+
+        Args:
+            sorters: list of <key>:<direction> sort terms
+
+        Returns:
+            list of OpenSearch sort terms
+        """
+        if sorters:
+            sort_terms = []
+            for s in sorters:
+                key, dir = s.split(":", maxsplit=1)
+                if dir not in cls.DIRECTIONS:
+                    raise HTTPException(
+                        status.HTTP_400_BAD_REQUEST,
+                        f"Sort direction {dir!r} must be one of {','.join(DIRECTIONS)}",
+                    )
+                if key not in cls.FIELDS:
+                    raise HTTPException(
+                        status.HTTP_400_BAD_REQUEST,
+                        f"Sort key {key!r} must be one of {','.join(FIELDS)}",
+                    )
+                sort_terms.append({f"run.{key}": dir})
+        else:
+            sort_terms = [{"run.begin": "asc"}]
+        return sort_terms
+
+    async def _search(
+        self, index: str, query: Optional[dict[str, Any]] = None, **kwargs
+    ) -> dict[str, Any]:
+        """Issue an OpenSearch query
+
+        Args:
+            index: The "base" CDM index name, e.g., "run", "metric_desc"
+            query: An OpenSearch query object
+            kwargs: Additional OpenSearch parameters
+
+        Returns:
+            The OpenSearch response payload (JSON dict)
+        """
+        idx = self._get_index(index)
+        start = time.time()
+        value = await self.elastic.search(index=idx, body=query, **kwargs)
+        print(
+            f"QUERY on {idx} took {time.time() - start} seconds, "
+            f"hits: {value.get('hits', {}).get('total')}"
+        )
+        return value
+
+    async def close(self):
+        """Close the OpenSearch connection"""
+        if self.elastic:
+            await self.elastic.close()
+        self.elastic = None
+
+    async def search(
+        self,
+        index: str,
+        filters: Optional[list[dict[str, Any]]] = None,
+        aggregations: Optional[dict[str, Any]] = None,
+        sort: Optional[list[dict[str, str]]] = None,
+        source: Optional[str] = None,
+        size: Optional[int] = None,
+        offset: Optional[int] = None,
+        **kwargs,
+    ) -> dict[str, Any]:
+        """OpenSearch query helper
+
+        Combine index, filters, aggregations, sort, and pagination options
+        into an OpenSearch query.
+
+        Args:
+            index: "root" CDM index name ("run", "metric_desc", ...)
+            filters: list of JSON dict filter terms {"term": {"name": "value}}
+            aggregations: list of JSON dict aggregations {"name": {"term": "name"}}
+            sort: list of JSON dict sort terms ("name": "asc")
+            size: The number of hits to return; defaults to "very large"
+            offset: The number of hits to skip, for pagination
+            kwargs: Additional OpenSearch options
+
+        Returns:
+            The OpenSearch response
+        """
+        f = filters if filters else []
+        query = {
+            "size": self.BIGQUERY if size is None else size,
+            "query": {"bool": {"filter": f}},
+        }
+        if sort:
+            query.update({"sort": sort})
+        if source:
+            query.update({"_source": source})
+        if offset:
+            query.update({"from": offset})
+        if aggregations:
+            query.update({"aggs": aggregations})
+        return await self._search(index, query, **kwargs)
+
+    async def _get_metric_ids(
+        self,
+        run: str,
+        metric: str,
+        namelist: Optional[list[str]] = None,
+        periodlist: Optional[list[str]] = None,
+        aggregate: bool = False,
+    ) -> list[str]:
+        """Generate a list of matching metric_desc IDs
+
+        Given a specific run and metric name, and a set of breakout filters,
+        returns a list of metric desc IDs that match.
+
+        If a single ID is required to produce a consistent metric, and the
+        supplied filters produce more than one without aggregation, raise a
+        422 HTTP error (UNPROCESSABLE CONTENT) with a response body showing
+        the unsatisfied breakouts (name and available values).
+
+        Args:
+            run: run ID
+            metric: combined metric name (e.g., sar-net::packets-sec)
+            namelist: a list of breakout filters like "type=physical"
+            periodlist: a list of period IDs
+            aggregate: if True, allow multiple metric IDs
+
+        Returns:
+            A list of matching metric_desc ID value(s)
+        """
+        filters = self._build_metric_filters(run, metric, namelist, periodlist)
+        metrics = await self.search(
+            "metric_desc",
+            filters=filters,
+            ignore_unavailable=True,
+        )
+        if len(metrics["hits"]["hits"]) < 1:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                (
+                    f"No matches for {metric}"
+                    f"{('+' + ','.join(namelist) if namelist else '')}"
+                ),
+            )
+        ids = [h["metric_desc"]["id"] for h in self._hits(metrics)]
+        if len(ids) < 2 or aggregate:
+            return ids
+
+        # If we get here, the client asked for breakout data that doesn't
+        # resolve to a single metric stream, and didn't specify aggregation.
+        # Offer some help.
+        names = defaultdict(set)
+        periods = set()
+        response = {
+            "message": f"More than one metric ({len(ids)}) means "
+            "you should add breakout filters or aggregate."
+        }
+        for m in self._hits(metrics):
+            if "period" in m:
+                periods.add(m["period"]["id"])
+            for n, v in m["metric_desc"]["names"].items():
+                names[n].add(v)
+
+        # We want to help filter a consistent summary, so only show those
+        # breakout names with more than one value.
+        response["names"] = {n: sorted(v) for n, v in names.items() if v and len(v) > 1}
+        response["periods"] = list(periods)
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=response
+        )
+
+    async def _build_timestamp_range_filters(
+        self, periods: Optional[list[str]] = None
+    ) -> list[dict[str, Any]]:
+        """Create a timestamp range filter
+
+        This extracts the begin and end timestamps from the list of periods and
+        builds a timestamp filter range to select documents on or after the
+        earliest begin timestamp and on or before the latest end timestamp.
+
+        Args:
+            periods: a list of CDM period IDs
+
+        Returns:
+            Constructs a range filter for the earliest begin timestamp and the
+            latest end timestamp among the specified periods.
+        """
+        if periods:
+            ps = self._split_list(periods)
+            matches = await self.search(
+                "period", filters=[{"terms": {"period.id": ps}}]
+            )
+            start = None
+            end = None
+            for h in self._hits(matches):
+                p = h["period"]
+                st = p["begin"]
+                et = p["end"]
+
+                # If any period is missing a timestamp, use the run's timestamp
+                # instead to avoid blowing up on a CDM error.
+                if st is None:
+                    st = h["run"]["begin"]
+                if et is None:
+                    et = h["run"]["end"]
+                if st and (not start or st < start):
+                    start = st
+                if et and (not end or et > end):
+                    end = et
+            if start is None or end is None:
+                name = (
+                    f"{h['run']['benchmark']}:{h['run']['begin']}-"
+                    f"{h['iteration']['num']}-{h['sample']['num']}-"
+                    f"{p['name']}"
+                )
+                raise HTTPException(
+                    status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    f"Unable to compute {name!r} time range {start!r} -> {end!r}",
+                )
+            return [
+                {"range": {"metric_data.begin": {"gte": str(start)}}},
+                {"range": {"metric_data.end": {"lte": str(end)}}},
+            ]
+        else:
+            return []
+
+    async def _get_run_ids(
+        self, index: str, filters: Optional[list[dict[str, Any]]] = None
+    ) -> set[str]:
+        """Return a set of run IDs matching a filter
+
+        Documents in the specified index must have "run.id" fields. Returns
+        a set of unique run IDs matched by the filter in the specified index.
+
+        Args:
+            index: root CDM index name
+            filters: a list of OpenSearch filter terms
+
+        Returns:
+            a set of unique run ID values
+        """
+        filtered = await self.search(
+            index, source="run.id", filters=filters, ignore_unavailable=True
+        )
+        print(f"HITS: {filtered['hits']['hits']}")
+        return set([x for x in self._hits(filtered, ["run", "id"])])
+
+    async def get_run_filters(self) -> dict[str, dict[str, list[str]]]:
+        """Return possible tag and filter terms
+
+        Return a description of tag and param filter terms meaningful
+        across all datasets. TODO: we should support date-range and benchmark
+        filtering. Consider supporting all `run` API filtering, which would
+        allow adjusting the filter popups to drop options no longer relevant
+        to a given set.
+
+            {
+                "param": {
+                    {"gpus": [4", "8"]}
+                }
+            }
+
+        Returns:
+            A two-level JSON dict; the first level is the namespace (param or
+            tag), the second level key is the param/tag/field name and its value
+            is the set of values defined for that key.
+        """
+        tags = await self.search(
+            "tag",
+            size=0,
+            aggregations={
+                "key": {
+                    "terms": {"field": "tag.name", "size": self.BIGQUERY},
+                    "aggs": {
+                        "values": {"terms": {"field": "tag.val", "size": self.BIGQUERY}}
+                    },
+                }
+            },
+            ignore_unavailable=True,
+        )
+        params = await self.search(
+            "param",
+            size=0,
+            aggregations={
+                "key": {
+                    "terms": {"field": "param.arg", "size": self.BIGQUERY},
+                    "aggs": {
+                        "values": {
+                            "terms": {"field": "param.val", "size": self.BIGQUERY}
+                        }
+                    },
+                }
+            },
+            ignore_unavailable=True,
+        )
+        aggs = {
+            k: {"terms": {"field": f"run.{k}", "size": self.BIGQUERY}}
+            for k in self.RUN_FILTERS
+        }
+        runs = await self.search(
+            "run",
+            size=0,
+            aggregations=aggs,
+        )
+        result = defaultdict(lambda: defaultdict(lambda: set()))
+        for p in self._aggs(params, "key"):
+            for v in p["values"]["buckets"]:
+                result["param"][p["key"]].add(v["key"])
+        for t in self._aggs(tags, "key"):
+            for v in t["values"]["buckets"]:
+                result["tag"][t["key"]].add(v["key"])
+        for name in self.RUN_FILTERS:
+            for f in self._aggs(runs, name):
+                result["run"][name].add(f["key"])
+        return {s: {k: list(v) for k, v in keys.items()} for s, keys in result.items()}
+
+    async def get_runs(
+        self,
+        filter: Optional[list[str]] = None,
+        start: Optional[Union[int, str, datetime]] = None,
+        end: Optional[Union[int, str, datetime]] = None,
+        offset: int = 0,
+        sort: Optional[list[str]] = None,
+        size: Optional[int] = None,
+        **kwargs,
+    ) -> dict[str, Any]:
+        """Return matching Crucible runs
+
+        Filtered and sorted list of runs.
+
+        {
+            "sort": [],
+            "startDate": "2024-01-01T05:00:00+00:00",
+            "size": 1,
+            "offset": 0,
+            "results": [
+                {
+                    "begin": "1722878906342",
+                    "benchmark": "ilab",
+                    "email": "A@email",
+                    "end": "1722880503544",
+                    "id": "4e1d2c3c-b01c-4007-a92d-23a561af2c11",
+                    "name": "\"A User\"",
+                    "source": "node.example.com//var/lib/crucible/run/ilab--2024-08-05_17:17:13_UTC--4e1d2c3c-b01c-4007-a92d-23a561af2c11",
+                    "tags": {
+                        "topology": "none"
+                    },
+                    "iterations": [
+                        {
+                            "iteration": 1,
+                            "primary_metric": "ilab::train-samples-sec",
+                            "primary_period": "measurement",
+                            "status": "pass",
+                            "params": {
+                                "cpu-offload-pin-memory": "1",
+                                "model": "/home/models/granite-7b-lab/",
+                                "data-path": "/home/data/training/knowledge_data.jsonl",
+                                "cpu-offload-optimizer": "1",
+                                "nnodes": "1",
+                                "nproc-per-node": "4",
+                                "num-runavg-samples": "2"
+                            }
+                        }
+                    ],
+                    "primary_metrics": [
+                        "ilab::train-samples-sec"
+                    ],
+                    "status": "pass",
+                    "params": {
+                        "cpu-offload-pin-memory": "1",
+                        "model": "/home/models/granite-7b-lab/",
+                        "data-path": "/home/data/training/knowledge_data.jsonl",
+                        "cpu-offload-optimizer": "1",
+                        "nnodes": "1",
+                        "nproc-per-node": "4",
+                        "num-runavg-samples": "2"
+                    },
+                    "begin_date": "2024-08-05 17:28:26.342000+00:00",
+                    "end_date": "2024-08-05 17:55:03.544000+00:00"
+                }
+            ],
+            "count": 1,
+            "total": 15,
+            "next_offset": 1
+        }
+
+        Args:
+            start: Include runs starting at timestamp
+            end: Include runs ending no later than timestamp
+            filter: List of tag/param filter terms (parm:key=value)
+            sort: List of sort terms (column:<dir>)
+            size: Include up to <size> runs in output
+            offset: Use size/from pagination instead of search_after
+
+        Returns:
+            JSON object with "results" list and "housekeeping" fields
+        """
+
+        # We need to remove runs which don't match against 'tag' or 'param'
+        # filter terms. The CDM schema doesn't make it possible to do this in
+        # one shot. Instead, we run queries against the param and tag indices
+        # separately, producing a list of run IDs which we'll exclude from the
+        # final collection.
+        #
+        # If there are no matches, we can exit early. (TODO: should this be an
+        # error, or just a success with an empty list?)
+        results = {}
+        filters = []
+        sorters = self._split_list(sort)
+        results["sort"] = sorters
+        sort_terms = self._build_sort_terms(sorters)
+        param_filters, tag_filters, run_filters = self._build_filter_options(filter)
+        if run_filters:
+            filters.extend(run_filters)
+        if start or end:
+            s = None
+            e = None
+            if start:
+                s = self._normalize_date(start)
+                results["startDate"] = datetime.fromtimestamp(
+                    s / 1000.0, tz=timezone.utc
+                )
+            if end:
+                e = self._normalize_date(end)
+                results["endDate"] = datetime.fromtimestamp(e / 1000.0, tz=timezone.utc)
+
+            if s and e and s > e:
+                raise HTTPException(
+                    status_code=422,
+                    detail={
+                        "error": "Invalid date format, start_date must be less than end_date"
+                    },
+                )
+            cond = {}
+            if s:
+                cond["gte"] = str(s)
+            if e:
+                cond["lte"] = str(e)
+            filters.append({"range": {"run.begin": cond}})
+        if size:
+            results["size"] = size
+        results["offset"] = offset if offset is not None else 0
+
+        # In order to filter by param or tag values, we need to produce a list
+        # of matching RUN IDs from each index. We'll then drop any RUN ID that's
+        # not on both lists.
+        if tag_filters:
+            tagids = await self._get_run_ids("tag", tag_filters)
+        if param_filters:
+            paramids = await self._get_run_ids("param", param_filters)
+
+        # If it's obvious we can't produce any matches at this point, exit.
+        if (tag_filters and len(tagids) == 0) or (param_filters and len(paramids) == 0):
+            results.update({"results": [], "count": 0, "total": 0})
+            return results
+
+        hits = await self.search(
+            "run",
+            size=size,
+            offset=offset,
+            sort=sort_terms,
+            filters=filters,
+            **kwargs,
+            ignore_unavailable=True,
+        )
+        rawiterations = await self.search("iteration", ignore_unavailable=True)
+        rawtags = await self.search("tag", ignore_unavailable=True)
+        rawparams = await self.search("param", ignore_unavailable=True)
+
+        iterations = defaultdict(list)
+        tags = defaultdict(defaultdict)
+        params = defaultdict(defaultdict)
+        run_params = defaultdict(list)
+
+        for i in self._hits(rawiterations):
+            iterations[i["run"]["id"]].append(i["iteration"])
+
+        # Organize tags by run ID
+        for t in self._hits(rawtags):
+            tags[t["run"]["id"]][t["tag"]["name"]] = t["tag"]["val"]
+
+        # Organize params by iteration ID
+        for p in self._hits(rawparams):
+            run_params[p["run"]["id"]].append(p)
+            params[p["iteration"]["id"]][p["param"]["arg"]] = p["param"]["val"]
+
+        runs = {}
+        for h in self._hits(hits):
+            run = h["run"]
+            rid = run["id"]
+
+            # Filter the runs by our tag and param queries
+            if param_filters and rid not in paramids:
+                continue
+
+            if tag_filters and rid not in tagids:
+                continue
+
+            # Collect unique runs: the status is "fail" if any iteration for
+            # that run ID failed.
+            runs[rid] = run
+            run["tags"] = tags.get(rid, {})
+            run["iterations"] = []
+            run["primary_metrics"] = set()
+            common = CommonParams()
+            for i in iterations.get(rid, []):
+                iparams = params.get(i["id"], {})
+                if "status" not in run:
+                    run["status"] = i["status"]
+                else:
+                    if i["status"] != "pass":
+                        run["status"] = i["status"]
+                common.add(iparams)
+                run["primary_metrics"].add(i["primary-metric"])
+                run["iterations"].append(
+                    {
+                        "iteration": i["num"],
+                        "primary_metric": i["primary-metric"],
+                        "primary_period": i["primary-period"],
+                        "status": i["status"],
+                        "params": iparams,
+                    }
+                )
+            run["params"] = common.render()
+            try:
+                run["begin_date"] = self._format_timestamp(run["begin"])
+                run["end_date"] = self._format_timestamp(run["end"])
+            except KeyError as e:
+                print(f"Missing 'run' key {str(e)} in {run}")
+                run["begin_date"] = self._format_timestamp("0")
+                run["end_date"] = self._format_timestamp("0")
+
+        count = len(runs)
+        total = hits["hits"]["total"]["value"]
+        results.update(
+            {
+                "results": list(runs.values()),
+                "count": count,
+                "total": total,
+            }
+        )
+        if size and (offset + count < total):
+            results["next_offset"] = offset + size
+        return results
+
+    async def get_tags(self, run: str, **kwargs) -> dict[str, str]:
+        """Return the set of tags associated with a run
+
+        Args:
+            run: run ID
+
+        Returns:
+            JSON dict with "tag" keys showing each value
+        """
+        tags = await self.search(
+            index="tag",
+            filters=[{"term": {"run.id": run}}],
+            **kwargs,
+            ignore_unavailable=True,
+        )
+        return {t["name"]: t["val"] for t in self._hits(tags, ["tag"])}
+
+    async def get_params(
+        self, run: Optional[str] = None, iteration: Optional[str] = None, **kwargs
+    ) -> dict[str, dict[str, str]]:
+        """Return the set of parameters for a run or iteration
+
+        Parameters are technically associated with an iteration, but can be
+        aggregated for a run. This will return a set of parameters for each
+        iteration; plus, if a "run" was specified, a filtered list of param
+        values that are common across all iterations.
+
+        Args:
+            run: run ID
+            iteration: iteration ID
+            kwargs: additional OpenSearch keywords
+
+        Returns:
+            JSON dict of param values by iteration (plus "common" if by run ID)
+        """
+        if not run and not iteration:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                "A params query requires either a run or iteration ID",
+            )
+        match = {"run.id" if run else "iteration.id": run if run else iteration}
+        params = await self.search(
+            index="param",
+            filters=[{"term": match}],
+            **kwargs,
+            ignore_unavailable=True,
+        )
+        response = defaultdict(defaultdict)
+        for param in self._hits(params):
+            iter = param["iteration"]["id"]
+            arg = param["param"]["arg"]
+            val = param["param"]["val"]
+            if response.get(iter) and response.get(iter).get(arg):
+                print(f"Duplicate param {arg} for iteration {iter}")
+            response[iter][arg] = val
+
+        # Filter out all parameter values that don't exist in all or which have
+        # different values.
+        if run:
+            common = CommonParams()
+            for params in response.values():
+                common.add(params)
+            response["common"] = common.render()
+        return response
+
+    async def get_iterations(self, run: str, **kwargs) -> list[dict[str, Any]]:
+        """Return a list of iterations for a run
+
+        Args:
+            run: run ID
+            kwargs: additional OpenSearch keywords
+
+        Returns:
+            A list of iteration documents
+        """
+        iterations = await self.search(
+            index="iteration",
+            filters=[{"term": {"run.id": run}}],
+            sort=[{"iteration.num": "asc"}],
+            **kwargs,
+            ignore_unavailable=True,
+        )
+        return [i["iteration"] for i in self._hits(iterations)]
+
+    async def get_samples(
+        self, run: Optional[str] = None, iteration: Optional[str] = None, **kwargs
+    ):
+        """Return a list of samples for a run or iteration
+
+        Args:
+            run: run ID
+            iteration: iteration ID
+            kwargs: additional OpenSearch keywords
+
+        Returns:
+            A list of sample documents.
+        """
+        if not run and not iteration:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                "A sample query requires either a run or iteration ID",
+            )
+        match = {"run.id" if run else "iteration.id": run if run else iteration}
+        hits = await self.search(
+            index="sample",
+            filters=[{"term": match}],
+            **kwargs,
+            ignore_unavailable=True,
+        )
+        samples = []
+        for s in self._hits(hits):
+            print(f"SAMPLE's ITERATION {s['iteration']}")
+            sample = s["sample"]
+            sample["iteration"] = s["iteration"]["num"]
+            sample["primary_metric"] = s["iteration"]["primary-metric"]
+            sample["status"] = s["iteration"]["status"]
+            samples.append(sample)
+        return samples
+
+    async def get_periods(
+        self,
+        run: Optional[str] = None,
+        iteration: Optional[str] = None,
+        sample: Optional[str] = None,
+        **kwargs,
+    ):
+        """Return a list of periods associated with a run, an iteration, or a
+        sample
+
+        The "period" document is normalized to represent timestamps using ISO
+        strings.
+
+        Args:
+            run: run ID
+            iteration: iteration ID
+            sample: sample ID
+            kwargs: additional OpenSearch parameters
+
+        Returns:
+            a list of normalized period documents
+        """
+        if not any((run, iteration, sample)):
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                "A period query requires a run, iteration, or sample ID",
+            )
+        match = None
+        if sample:
+            match = {"sample.id": sample}
+        elif iteration:
+            match = {"iteration.id": iteration}
+        else:
+            match = {"run.id": run}
+        periods = await self.search(
+            index="period",
+            filters=[{"term": match}],
+            sort=[{"period.begin": "asc"}],
+            **kwargs,
+            ignore_unavailable=True,
+        )
+        body = []
+        for h in self._hits(periods):
+            period = self._format_period(period=h["period"])
+            period["iteration"] = h["iteration"]["num"]
+            period["sample"] = h["sample"]["num"]
+            period["primary_metric"] = h["iteration"]["primary-metric"]
+            period["status"] = h["iteration"]["status"]
+            body.append(period)
+        return body
+
+    async def get_timeline(self, run: str, **kwargs) -> dict[str, Any]:
+        """Report the relative timeline of a run
+
+        With nested object lists, show runs to iterations to samples to
+        periods.
+
+        Args:
+            run: run ID
+            kwargs: additional OpenSearch parameters
+        """
+        itr = await self.search(
+            index="iteration",
+            filters=[{"term": {"run.id": run}}],
+            **kwargs,
+            ignore_unavailable=True,
+        )
+        sam = await self.search(
+            index="sample",
+            filters=[{"term": {"run.id": run}}],
+            **kwargs,
+            ignore_unavailable=True,
+        )
+        per = await self.search(
+            index="period",
+            filters=[{"term": {"run.id": run}}],
+            **kwargs,
+            ignore_unavailable=True,
+        )
+        samples = defaultdict(list)
+        periods = defaultdict(list)
+
+        for s in self._hits(sam):
+            samples[s["iteration"]["id"]].append(s)
+        for p in self._hits(per):
+            periods[p["sample"]["id"]].append(p)
+
+        iterations = []
+        robj = {"id": run, "iterations": iterations}
+        body = {"run": robj}
+        for i in self._hits(itr):
+            if "begin" not in robj:
+                robj["begin"] = self._format_timestamp(i["run"]["begin"])
+                robj["end"] = self._format_timestamp(i["run"]["end"])
+            iteration = i["iteration"]
+            iterations.append(iteration)
+            iteration["samples"] = []
+            for s in samples.get(iteration["id"], []):
+                sample = s["sample"]
+                sample["periods"] = []
+                for pr in periods.get(sample["id"], []):
+                    period = self._format_period(pr["period"])
+                    sample["periods"].append(period)
+                iteration["samples"].append(sample)
+        return body
+
+    async def get_metrics_list(self, run: str, **kwargs) -> dict[str, Any]:
+        """Return a list of metrics available for a run
+
+        Each run may have multiple performance metrics stored. This API allows
+        retrieving a sorted list of the metrics available for a given run, with
+        the "names" selection criteria available for each and, for "periodic"
+        (benchmark) metrics, the defined periods for which data was gathered.
+
+        {
+            "ilab::train-samples-sec": {
+                "periods": [{"id": <id>, "name": "measurement"}],
+                "breakouts": {"benchmark-group" ["unknown"], ...}
+            },
+            "iostat::avg-queue-length": {
+                "periods": [],
+                "breakouts": {"benchmark-group": ["unknown"], ...},
+            },
+            ...
+        }
+
+        Args:
+            run: run ID
+
+        Returns:
+            List of metrics available for the run
+        """
+        hits = await self.search(
+            index="metric_desc",
+            filters=[{"term": {"run.id": run}}],
+            ignore_unavailable=True,
+            **kwargs,
+        )
+        met = {}
+        for h in self._hits(hits):
+            desc = h["metric_desc"]
+            name = desc["source"] + "::" + desc["type"]
+            if name in met:
+                record = met[name]
+            else:
+                record = {"periods": [], "breakouts": defaultdict(set)}
+                met[name] = record
+            if "period" in h:
+                record["periods"].append(h["period"]["id"])
+            for n, v in desc["names"].items():
+                record["breakouts"][n].add(v)
+        return met
+
+    async def get_metric_breakouts(
+        self,
+        run: str,
+        metric: str,
+        names: Optional[list[str]] = None,
+        periods: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        """Help explore available metric breakouts
+
+        Args:
+            run: run ID
+            metric: metric label (e.g., "mpstat::Busy-CPU")
+            names: list of name filters ("cpu=3")
+            periods: list of period IDs
+
+        Returns:
+            A description of all breakout names and values, which can be
+            specified to narrow down metrics returns by the data, summary, and
+            graph APIs.
+
+            {
+                "label": "mpstat::Busy-CPU",
+                "class": [
+                    "throughput"
+                ],
+                "type": "Busy-CPU",
+                "source": "mpstat",
+                "breakouts": {
+                    "num": [
+                        "8",
+                        "72"
+                    ],
+                    "thread": [
+                        0,
+                        1
+                    ]
+                }
+            }
+        """
+        start = time.time()
+        filters = self._build_metric_filters(run, metric, names, periods)
+        metric_name = metric + ("" if not names else ("+" + ",".join(names)))
+        metrics = await self.search(
+            "metric_desc",
+            filters=filters,
+            ignore_unavailable=True,
+        )
+        if len(metrics["hits"]["hits"]) < 1:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                f"Metric name {metric_name} not found for run {run}",
+            )
+        classes = set()
+        response = {"label": metric, "class": classes}
+        breakouts = defaultdict(set)
+        pl = set()
+        for m in self._hits(metrics):
+            desc = m["metric_desc"]
+            response["type"] = desc["type"]
+            response["source"] = desc["source"]
+            if desc.get("class"):
+                classes.add(desc["class"])
+            if "period" in m:
+                pl.add(m["period"]["id"])
+            for n, v in desc["names"].items():
+                breakouts[n].add(v)
+        # We want to help filter a consistent summary, so only show those
+        # names with more than one value.
+        if len(pl) > 1:
+            response["periods"] = pl
+        response["breakouts"] = {n: v for n, v in breakouts.items() if len(v) > 1}
+        duration = time.time() - start
+        print(f"Processing took {duration} seconds")
+        return response
+
+    async def get_metrics_data(
+        self,
+        run: str,
+        metric: str,
+        names: Optional[list[str]] = None,
+        periods: Optional[list[str]] = None,
+        aggregate: bool = False,
+    ) -> list[Any]:
+        """Return a list of metric data
+
+        The "aggregate" option allows aggregating various metrics across
+        breakout streams and periods: be careful, as this is meaningful only if
+        the breakout streams are sufficiently related.
+
+        Args:
+            run: run ID
+            metric: metric label (e.g., "mpstat::Busy-CPU")
+            names: list of name filters ("cpu=3")
+            periods: list of period IDs
+            aggregate: aggregate multiple metric data streams
+
+        Returns:
+            A sequence of data samples, showing the aggregate sample along with
+            the duration and end timestamp of each sample interval.
+
+            [
+                {
+                    "begin": "2024-08-22 20:03:23.028000+00:00",
+                    "end": "2024-08-22 20:03:37.127000+00:00",
+                    "duration": 14.1,
+                    "value": 9.35271216694379
+                },
+                {
+                    "begin": "2024-08-22 20:03:37.128000+00:00",
+                    "end": "2024-08-22 20:03:51.149000+00:00",
+                    "duration": 14.022,
+                    "value": 9.405932330557683
+                },
+                {
+                    "begin": "2024-08-22 20:03:51.150000+00:00",
+                    "end": "2024-08-22 20:04:05.071000+00:00",
+                    "duration": 13.922,
+                    "value": 9.478773265522682
+                }
+            ]
+        """
+        start = time.time()
+        ids = await self._get_metric_ids(
+            run, metric, names, periodlist=periods, aggregate=aggregate
+        )
+
+        # If we're searching by periods, filter metric data by the period
+        # timestamp range rather than just relying on the metric desc IDs as
+        # we also want to filter non-periodic tool data.
+        filters = [{"terms": {"metric_desc.id": ids}}]
+        filters.extend(await self._build_timestamp_range_filters(periods))
+
+        response = []
+        if len(ids) > 1:
+            # Find the minimum sample interval of the selected metrics
+            aggdur = await self.search(
+                "metric_data",
+                size=0,
+                filters=filters,
+                aggregations={"duration": {"stats": {"field": "metric_data.duration"}}},
+            )
+            if aggdur["aggregations"]["duration"]["count"] > 0:
+                interval = int(aggdur["aggregations"]["duration"]["min"])
+                data = await self.search(
+                    index="metric_data",
+                    size=0,
+                    filters=filters,
+                    aggregations={
+                        "interval": {
+                            "histogram": {
+                                "field": "metric_data.end",
+                                "interval": interval,
+                            },
+                            "aggs": {"value": {"sum": {"field": "metric_data.value"}}},
+                        }
+                    },
+                )
+                for h in self._aggs(data, "interval"):
+                    response.append(
+                        {
+                            "begin": self._format_timestamp(h["key"] - interval),
+                            "end": self._format_timestamp(h["key"]),
+                            "value": h["value"]["value"],
+                            "duration": interval / 1000.0,
+                        }
+                    )
+        else:
+            data = await self.search("metric_data", filters=filters)
+            for h in self._hits(data, ["metric_data"]):
+                response.append(self._format_data(h))
+        response.sort(key=lambda a: a["end"])
+        duration = time.time() - start
+        print(f"Processing took {duration} seconds")
+        return response
+
+    async def get_metrics_summary(
+        self,
+        run: str,
+        metric: str,
+        names: Optional[list[str]] = None,
+        periods: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        """Return a statistical summary of metric data
+
+        Provides a statistical summary of selected data samples.
+
+        Args:
+            run: run ID
+            metric: metric label (e.g., "mpstat::Busy-CPU")
+            names: list of name filters ("cpu=3")
+            periods: list of period IDs
+
+        Returns:
+            A statistical summary of the selected metric data
+
+            {
+                "count": 71,
+                "min": 0.0,
+                "max": 0.3296,
+                "avg": 0.02360704225352113,
+                "sum": 1.676self.BIGQUERY00000001
+            }
+        """
+        start = time.time()
+        ids = await self._get_metric_ids(run, metric, names, periodlist=periods)
+        filters = [{"terms": {"metric_desc.id": ids}}]
+        filters.extend(await self._build_timestamp_range_filters(periods))
+        data = await self.search(
+            "metric_data",
+            size=0,
+            filters=filters,
+            aggregations={"score": {"stats": {"field": "metric_data.value"}}},
+        )
+        duration = time.time() - start
+        print(f"Processing took {duration} seconds")
+        return data["aggregations"]["score"]
+
+    async def _graph_title(
+        self,
+        run_id: str,
+        run_id_list: list[str],
+        graph: Graph,
+        params_by_run: dict[str, Any],
+        periods_by_run: dict[str, Any],
+    ) -> str:
+        """Compute a default title for a graph
+
+        Use the period, breakout name selections, run list, and iteration
+        parameters to construct a meaningful name for a graph.
+
+        For example, "ilab::sdg-samples-sec (batch-size=4) {run 1}", or
+        "mpstat::Busy-CPU [cpu=4]"
+
+        Args:
+            run_id: the Crucible run ID
+            run_id_list: ordered list of run IDs in our list of graphs
+            graph: the current Graph object
+            params_by_run: initially empty dict used to cache parameters
+            periods_by_run: initially empty dict used to cache periods
+
+        Returns:
+            A string title
+        """
+        names = graph.names
+        metric = graph.metric
+        if run_id not in params_by_run:
+            # Gather iteration parameters outside the loop for help in
+            # generating useful labels.
+            all_params = await self.search(
+                "param", filters=[{"term": {"run.id": run_id}}]
+            )
+            collector = defaultdict(defaultdict)
+            for h in self._hits(all_params):
+                collector[h["iteration"]["id"]][h["param"]["arg"]] = h["param"]["val"]
+            params_by_run[run_id] = collector
+        else:
+            collector = params_by_run[run_id]
+
+        if run_id not in periods_by_run:
+            periods = await self.search(
+                "period", filters=[{"term": {"run.id": run_id}}]
+            )
+            iteration_periods = defaultdict(set)
+            for p in self._hits(periods):
+                iteration_periods[p["iteration"]["id"]].add(p["period"]["id"])
+            periods_by_run[run_id] = iteration_periods
+        else:
+            iteration_periods = periods_by_run[run_id]
+
+        # We can easily end up with multiple graphs across distinct
+        # periods or iterations, so we want to be able to provide some
+        # labeling to the graphs. We do this by looking for unique
+        # iteration parameters values, since the iteration number and
+        # period name aren't useful by themselves.
+        name_suffix = ""
+        if graph.periods:
+            iteration = None
+            for i, pset in iteration_periods.items():
+                if set(graph.periods) <= pset:
+                    iteration = i
+                    break
+
+            # If the period(s) we're graphing resolve to a single
+            # iteration in a run with multiple iterations, then we can
+            # try to find a unique title suffix based on distinct param
+            # values for that iteration.
+            if iteration and len(collector) > 1:
+                unique = collector[iteration].copy()
+                for i, params in collector.items():
+                    if i != iteration:
+                        for p in list(unique.keys()):
+                            if p in params and unique[p] == params[p]:
+                                del unique[p]
+                if unique:
+                    name_suffix = (
+                        " (" + ",".join([f"{p}={v}" for p, v in unique.items()]) + ")"
+                    )
+
+        if len(run_id_list) > 1:
+            name_suffix += f" {{run {run_id_list.index(run_id) + 1}}}"
+
+        options = (" [" + ",".join(names) + "]") if names else ""
+        return metric + options + name_suffix
+
+    async def get_metrics_graph(self, graphdata: GraphList) -> dict[str, Any]:
+        """Return metrics data for a run
+
+        Each run may have multiple performance metrics stored. This API allows
+        retrieving graphable time-series representation of a metric over the
+        period of the run, in the format defined by Plotly as configuration
+        settings plus an x value array and a y value array.
+
+        {
+            "data": [
+                {
+                "x": [
+                    "2024-08-27 09:16:27.371000",
+                    ...
+                ],
+                "y": [
+                    10.23444312132161,
+                    ...
+                ],
+                "name": "Metric ilab::train-samples-sec",
+                "type": "scatter",
+                "mode": "line",
+                "marker": {"color": "black"},
+                "labels": {"x": "sample timestamp", "y": "samples / second"}
+                }
+            ]
+            "layout": {
+                "width": 1500,
+                "yaxis": {
+                    "title": "mpstat::Busy-CPU core=2,package=0,num=112,type=usr",
+                    "color": "black"
+                }
+            }
+        }
+
+        Args:
+            graphdata: A GraphList object
+
+        Returns:
+            A Plotly object with layout
+        """
+        start = time.time()
+        graphlist = []
+        default_run_id = graphdata.run
+        layout: dict[str, Any] = {"width": "1500"}
+        axes = {}
+        yaxis = None
+        cindex = 0
+        params_by_run = {}
+        periods_by_run = {}
+
+        # Construct a de-duped ordered list of run IDs, starting with the
+        # default.
+        run_id_list = []
+        if default_run_id:
+            run_id_list.append(default_run_id)
+        run_id_missing = False
+        for g in graphdata.graphs:
+            if g.run:
+                if g.run not in run_id_list:
+                    run_id_list.append(g.run)
+            else:
+                run_id_missing = True
+
+        if run_id_missing and not default_run_id:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST, "each graph request must have a run ID"
+            )
+
+        for g in graphdata.graphs:
+            run_id = g.run if g.run else default_run_id
+            names = g.names
+            metric: str = g.metric
+
+            # The caller can provide a title for each graph; but, if not, we
+            # journey down dark overgrown pathways to fabricate a default with
+            # reasonable context, including unique iteration parameters,
+            # breakdown selections, and which run provided the data.
+            if g.title:
+                title = g.title
+            else:
+                title = await self._graph_title(
+                    run_id, run_id_list, g, params_by_run, periods_by_run
+                )
+
+            ids = await self._get_metric_ids(
+                run_id,
+                metric,
+                names,
+                periodlist=g.periods,
+                aggregate=g.aggregate,
+            )
+            filters = [{"terms": {"metric_desc.id": ids}}]
+            filters.extend(await self._build_timestamp_range_filters(g.periods))
+            y_max = 0.0
+            points: list[Point] = []
+
+            # If we're pulling multiple breakouts, e.g., total CPU across modes
+            # or cores, we want to aggregate by timestamp interval. Sample
+            # timstamps don't necessarily align, so the "histogram" aggregation
+            # normalizes within the interval (based on the minimum actual
+            # interval duration).
+            if len(ids) > 1:
+                # Find the minimum sample interval of the selected metrics
+                aggdur = await self.search(
+                    "metric_data",
+                    size=0,
+                    filters=filters,
+                    aggregations={
+                        "duration": {"stats": {"field": "metric_data.duration"}}
+                    },
+                )
+                if aggdur["aggregations"]["duration"]["count"] > 0:
+                    interval = int(aggdur["aggregations"]["duration"]["min"])
+                    data = await self.search(
+                        index="metric_data",
+                        size=0,
+                        filters=filters,
+                        aggregations={
+                            "interval": {
+                                "histogram": {
+                                    "field": "metric_data.begin",
+                                    "interval": interval,
+                                },
+                                "aggs": {
+                                    "value": {"sum": {"field": "metric_data.value"}}
+                                },
+                            }
+                        },
+                    )
+                    for h in self._aggs(data, "interval"):
+                        begin = int(h["key"])
+                        end = begin + interval - 1
+                        points.append(Point(begin, end, float(h["value"]["value"])))
+            else:
+                data = await self.search("metric_data", filters=filters)
+                for h in self._hits(data, ["metric_data"]):
+                    points.append(
+                        Point(int(h["begin"]), int(h["end"]), float(h["value"]))
+                    )
+
+            # Sort the graph points by timestamp so that Ploty will draw nice
+            # lines. We graph both the "begin" and "end" timestamp of each
+            # sample against the value to more clearly show the sampling
+            # interval.
+            x = []
+            y = []
+
+            for p in sorted(points, key=lambda a: a.begin):
+                x.extend(
+                    [self._format_timestamp(p.begin), self._format_timestamp(p.end)]
+                )
+                y.extend([p.value, p.value])
+                y_max = max(y_max, p.value)
+
+            if g.color:
+                color = g.color
+            else:
+                color = colors[cindex]
+                cindex += 1
+                if cindex >= len(colors):
+                    cindex = 0
+            graphitem = {
+                "x": x,
+                "y": y,
+                "name": title,
+                "type": "scatter",
+                "mode": "line",
+                "marker": {"color": color},
+                "labels": {
+                    "x": "sample timestamp",
+                    "y": "samples / second",
+                },
+            }
+
+            # Y-axis scaling and labeling is divided by benchmark label;
+            # so store each we've created to reuse. (E.g., if we graph
+            # 5 different mpstat::Busy-CPU periods, they'll share a single
+            # Y axis.)
+            if metric in axes:
+                yref = axes[metric]
+            else:
+                if yaxis:
+                    name = f"yaxis{yaxis}"
+                    yref = f"y{yaxis}"
+                    yaxis += 1
+                    layout[name] = {
+                        "title": metric,
+                        "color": color,
+                        "autorange": True,
+                        "anchor": "free",
+                        "autoshift": True,
+                        "overlaying": "y",
+                    }
+                else:
+                    name = "yaxis"
+                    yref = "y"
+                    yaxis = 2
+                    layout[name] = {
+                        "title": metric,
+                        "color": color,
+                    }
+                axes[metric] = yref
+            graphitem["yaxis"] = yref
+            graphlist.append(graphitem)
+        duration = time.time() - start
+        print(f"Processing took {duration} seconds")
+        return {"data": graphlist, "layout": layout}

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -14,88 +14,88 @@ files = [
 
 [[package]]
 name = "aiohttp"
-version = "3.11.11"
+version = "3.11.10"
 description = "Async http client/server framework (asyncio)"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "aiohttp-3.11.11-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a60804bff28662cbcf340a4d61598891f12eea3a66af48ecfdc975ceec21e3c8"},
-    {file = "aiohttp-3.11.11-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4b4fa1cb5f270fb3eab079536b764ad740bb749ce69a94d4ec30ceee1b5940d5"},
-    {file = "aiohttp-3.11.11-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:731468f555656767cda219ab42e033355fe48c85fbe3ba83a349631541715ba2"},
-    {file = "aiohttp-3.11.11-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb23d8bb86282b342481cad4370ea0853a39e4a32a0042bb52ca6bdde132df43"},
-    {file = "aiohttp-3.11.11-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f047569d655f81cb70ea5be942ee5d4421b6219c3f05d131f64088c73bb0917f"},
-    {file = "aiohttp-3.11.11-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dd7659baae9ccf94ae5fe8bfaa2c7bc2e94d24611528395ce88d009107e00c6d"},
-    {file = "aiohttp-3.11.11-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:af01e42ad87ae24932138f154105e88da13ce7d202a6de93fafdafb2883a00ef"},
-    {file = "aiohttp-3.11.11-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5854be2f3e5a729800bac57a8d76af464e160f19676ab6aea74bde18ad19d438"},
-    {file = "aiohttp-3.11.11-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6526e5fb4e14f4bbf30411216780c9967c20c5a55f2f51d3abd6de68320cc2f3"},
-    {file = "aiohttp-3.11.11-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:85992ee30a31835fc482468637b3e5bd085fa8fe9392ba0bdcbdc1ef5e9e3c55"},
-    {file = "aiohttp-3.11.11-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:88a12ad8ccf325a8a5ed80e6d7c3bdc247d66175afedbe104ee2aaca72960d8e"},
-    {file = "aiohttp-3.11.11-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:0a6d3fbf2232e3a08c41eca81ae4f1dff3d8f1a30bae415ebe0af2d2458b8a33"},
-    {file = "aiohttp-3.11.11-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:84a585799c58b795573c7fa9b84c455adf3e1d72f19a2bf498b54a95ae0d194c"},
-    {file = "aiohttp-3.11.11-cp310-cp310-win32.whl", hash = "sha256:bfde76a8f430cf5c5584553adf9926534352251d379dcb266ad2b93c54a29745"},
-    {file = "aiohttp-3.11.11-cp310-cp310-win_amd64.whl", hash = "sha256:0fd82b8e9c383af11d2b26f27a478640b6b83d669440c0a71481f7c865a51da9"},
-    {file = "aiohttp-3.11.11-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ba74ec819177af1ef7f59063c6d35a214a8fde6f987f7661f4f0eecc468a8f76"},
-    {file = "aiohttp-3.11.11-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4af57160800b7a815f3fe0eba9b46bf28aafc195555f1824555fa2cfab6c1538"},
-    {file = "aiohttp-3.11.11-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ffa336210cf9cd8ed117011085817d00abe4c08f99968deef0013ea283547204"},
-    {file = "aiohttp-3.11.11-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:81b8fe282183e4a3c7a1b72f5ade1094ed1c6345a8f153506d114af5bf8accd9"},
-    {file = "aiohttp-3.11.11-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3af41686ccec6a0f2bdc66686dc0f403c41ac2089f80e2214a0f82d001052c03"},
-    {file = "aiohttp-3.11.11-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:70d1f9dde0e5dd9e292a6d4d00058737052b01f3532f69c0c65818dac26dc287"},
-    {file = "aiohttp-3.11.11-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:249cc6912405917344192b9f9ea5cd5b139d49e0d2f5c7f70bdfaf6b4dbf3a2e"},
-    {file = "aiohttp-3.11.11-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0eb98d90b6690827dcc84c246811feeb4e1eea683c0eac6caed7549be9c84665"},
-    {file = "aiohttp-3.11.11-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ec82bf1fda6cecce7f7b915f9196601a1bd1a3079796b76d16ae4cce6d0ef89b"},
-    {file = "aiohttp-3.11.11-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:9fd46ce0845cfe28f108888b3ab17abff84ff695e01e73657eec3f96d72eef34"},
-    {file = "aiohttp-3.11.11-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:bd176afcf8f5d2aed50c3647d4925d0db0579d96f75a31e77cbaf67d8a87742d"},
-    {file = "aiohttp-3.11.11-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:ec2aa89305006fba9ffb98970db6c8221541be7bee4c1d027421d6f6df7d1ce2"},
-    {file = "aiohttp-3.11.11-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:92cde43018a2e17d48bb09c79e4d4cb0e236de5063ce897a5e40ac7cb4878773"},
-    {file = "aiohttp-3.11.11-cp311-cp311-win32.whl", hash = "sha256:aba807f9569455cba566882c8938f1a549f205ee43c27b126e5450dc9f83cc62"},
-    {file = "aiohttp-3.11.11-cp311-cp311-win_amd64.whl", hash = "sha256:ae545f31489548c87b0cced5755cfe5a5308d00407000e72c4fa30b19c3220ac"},
-    {file = "aiohttp-3.11.11-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e595c591a48bbc295ebf47cb91aebf9bd32f3ff76749ecf282ea7f9f6bb73886"},
-    {file = "aiohttp-3.11.11-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3ea1b59dc06396b0b424740a10a0a63974c725b1c64736ff788a3689d36c02d2"},
-    {file = "aiohttp-3.11.11-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8811f3f098a78ffa16e0ea36dffd577eb031aea797cbdba81be039a4169e242c"},
-    {file = "aiohttp-3.11.11-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd7227b87a355ce1f4bf83bfae4399b1f5bb42e0259cb9405824bd03d2f4336a"},
-    {file = "aiohttp-3.11.11-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d40f9da8cabbf295d3a9dae1295c69975b86d941bc20f0a087f0477fa0a66231"},
-    {file = "aiohttp-3.11.11-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ffb3dc385f6bb1568aa974fe65da84723210e5d9707e360e9ecb51f59406cd2e"},
-    {file = "aiohttp-3.11.11-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8f5f7515f3552d899c61202d99dcb17d6e3b0de777900405611cd747cecd1b8"},
-    {file = "aiohttp-3.11.11-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3499c7ffbfd9c6a3d8d6a2b01c26639da7e43d47c7b4f788016226b1e711caa8"},
-    {file = "aiohttp-3.11.11-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8e2bf8029dbf0810c7bfbc3e594b51c4cc9101fbffb583a3923aea184724203c"},
-    {file = "aiohttp-3.11.11-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:b6212a60e5c482ef90f2d788835387070a88d52cf6241d3916733c9176d39eab"},
-    {file = "aiohttp-3.11.11-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:d119fafe7b634dbfa25a8c597718e69a930e4847f0b88e172744be24515140da"},
-    {file = "aiohttp-3.11.11-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:6fba278063559acc730abf49845d0e9a9e1ba74f85f0ee6efd5803f08b285853"},
-    {file = "aiohttp-3.11.11-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:92fc484e34b733704ad77210c7957679c5c3877bd1e6b6d74b185e9320cc716e"},
-    {file = "aiohttp-3.11.11-cp312-cp312-win32.whl", hash = "sha256:9f5b3c1ed63c8fa937a920b6c1bec78b74ee09593b3f5b979ab2ae5ef60d7600"},
-    {file = "aiohttp-3.11.11-cp312-cp312-win_amd64.whl", hash = "sha256:1e69966ea6ef0c14ee53ef7a3d68b564cc408121ea56c0caa2dc918c1b2f553d"},
-    {file = "aiohttp-3.11.11-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:541d823548ab69d13d23730a06f97460f4238ad2e5ed966aaf850d7c369782d9"},
-    {file = "aiohttp-3.11.11-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:929f3ed33743a49ab127c58c3e0a827de0664bfcda566108989a14068f820194"},
-    {file = "aiohttp-3.11.11-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0882c2820fd0132240edbb4a51eb8ceb6eef8181db9ad5291ab3332e0d71df5f"},
-    {file = "aiohttp-3.11.11-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b63de12e44935d5aca7ed7ed98a255a11e5cb47f83a9fded7a5e41c40277d104"},
-    {file = "aiohttp-3.11.11-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aa54f8ef31d23c506910c21163f22b124facb573bff73930735cf9fe38bf7dff"},
-    {file = "aiohttp-3.11.11-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a344d5dc18074e3872777b62f5f7d584ae4344cd6006c17ba12103759d407af3"},
-    {file = "aiohttp-3.11.11-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b7fb429ab1aafa1f48578eb315ca45bd46e9c37de11fe45c7f5f4138091e2f1"},
-    {file = "aiohttp-3.11.11-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c341c7d868750e31961d6d8e60ff040fb9d3d3a46d77fd85e1ab8e76c3e9a5c4"},
-    {file = "aiohttp-3.11.11-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ed9ee95614a71e87f1a70bc81603f6c6760128b140bc4030abe6abaa988f1c3d"},
-    {file = "aiohttp-3.11.11-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:de8d38f1c2810fa2a4f1d995a2e9c70bb8737b18da04ac2afbf3971f65781d87"},
-    {file = "aiohttp-3.11.11-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:a9b7371665d4f00deb8f32208c7c5e652059b0fda41cf6dbcac6114a041f1cc2"},
-    {file = "aiohttp-3.11.11-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:620598717fce1b3bd14dd09947ea53e1ad510317c85dda2c9c65b622edc96b12"},
-    {file = "aiohttp-3.11.11-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf8d9bfee991d8acc72d060d53860f356e07a50f0e0d09a8dfedea1c554dd0d5"},
-    {file = "aiohttp-3.11.11-cp313-cp313-win32.whl", hash = "sha256:9d73ee3725b7a737ad86c2eac5c57a4a97793d9f442599bea5ec67ac9f4bdc3d"},
-    {file = "aiohttp-3.11.11-cp313-cp313-win_amd64.whl", hash = "sha256:c7a06301c2fb096bdb0bd25fe2011531c1453b9f2c163c8031600ec73af1cc99"},
-    {file = "aiohttp-3.11.11-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3e23419d832d969f659c208557de4a123e30a10d26e1e14b73431d3c13444c2e"},
-    {file = "aiohttp-3.11.11-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:21fef42317cf02e05d3b09c028712e1d73a9606f02467fd803f7c1f39cc59add"},
-    {file = "aiohttp-3.11.11-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1f21bb8d0235fc10c09ce1d11ffbd40fc50d3f08a89e4cf3a0c503dc2562247a"},
-    {file = "aiohttp-3.11.11-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1642eceeaa5ab6c9b6dfeaaa626ae314d808188ab23ae196a34c9d97efb68350"},
-    {file = "aiohttp-3.11.11-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2170816e34e10f2fd120f603e951630f8a112e1be3b60963a1f159f5699059a6"},
-    {file = "aiohttp-3.11.11-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8be8508d110d93061197fd2d6a74f7401f73b6d12f8822bbcd6d74f2b55d71b1"},
-    {file = "aiohttp-3.11.11-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4eed954b161e6b9b65f6be446ed448ed3921763cc432053ceb606f89d793927e"},
-    {file = "aiohttp-3.11.11-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d6c9af134da4bc9b3bd3e6a70072509f295d10ee60c697826225b60b9959acdd"},
-    {file = "aiohttp-3.11.11-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:44167fc6a763d534a6908bdb2592269b4bf30a03239bcb1654781adf5e49caf1"},
-    {file = "aiohttp-3.11.11-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:479b8c6ebd12aedfe64563b85920525d05d394b85f166b7873c8bde6da612f9c"},
-    {file = "aiohttp-3.11.11-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:10b4ff0ad793d98605958089fabfa350e8e62bd5d40aa65cdc69d6785859f94e"},
-    {file = "aiohttp-3.11.11-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:b540bd67cfb54e6f0865ceccd9979687210d7ed1a1cc8c01f8e67e2f1e883d28"},
-    {file = "aiohttp-3.11.11-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:1dac54e8ce2ed83b1f6b1a54005c87dfed139cf3f777fdc8afc76e7841101226"},
-    {file = "aiohttp-3.11.11-cp39-cp39-win32.whl", hash = "sha256:568c1236b2fde93b7720f95a890741854c1200fba4a3471ff48b2934d2d93fd3"},
-    {file = "aiohttp-3.11.11-cp39-cp39-win_amd64.whl", hash = "sha256:943a8b052e54dfd6439fd7989f67fc6a7f2138d0a2cf0a7de5f18aa4fe7eb3b1"},
-    {file = "aiohttp-3.11.11.tar.gz", hash = "sha256:bb49c7f1e6ebf3821a42d81d494f538107610c3a705987f53068546b0e90303e"},
+    {file = "aiohttp-3.11.10-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cbad88a61fa743c5d283ad501b01c153820734118b65aee2bd7dbb735475ce0d"},
+    {file = "aiohttp-3.11.10-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:80886dac673ceaef499de2f393fc80bb4481a129e6cb29e624a12e3296cc088f"},
+    {file = "aiohttp-3.11.10-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:61b9bae80ed1f338c42f57c16918853dc51775fb5cb61da70d590de14d8b5fb4"},
+    {file = "aiohttp-3.11.10-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e2e576caec5c6a6b93f41626c9c02fc87cd91538b81a3670b2e04452a63def6"},
+    {file = "aiohttp-3.11.10-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:02c13415b5732fb6ee7ff64583a5e6ed1c57aa68f17d2bda79c04888dfdc2769"},
+    {file = "aiohttp-3.11.10-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4cfce37f31f20800a6a6620ce2cdd6737b82e42e06e6e9bd1b36f546feb3c44f"},
+    {file = "aiohttp-3.11.10-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3bbbfff4c679c64e6e23cb213f57cc2c9165c9a65d63717108a644eb5a7398df"},
+    {file = "aiohttp-3.11.10-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:49c7dbbc1a559ae14fc48387a115b7d4bbc84b4a2c3b9299c31696953c2a5219"},
+    {file = "aiohttp-3.11.10-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:68386d78743e6570f054fe7949d6cb37ef2b672b4d3405ce91fafa996f7d9b4d"},
+    {file = "aiohttp-3.11.10-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:9ef405356ba989fb57f84cac66f7b0260772836191ccefbb987f414bcd2979d9"},
+    {file = "aiohttp-3.11.10-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:5d6958671b296febe7f5f859bea581a21c1d05430d1bbdcf2b393599b1cdce77"},
+    {file = "aiohttp-3.11.10-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:99b7920e7165be5a9e9a3a7f1b680f06f68ff0d0328ff4079e5163990d046767"},
+    {file = "aiohttp-3.11.10-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0dc49f42422163efb7e6f1df2636fe3db72713f6cd94688e339dbe33fe06d61d"},
+    {file = "aiohttp-3.11.10-cp310-cp310-win32.whl", hash = "sha256:40d1c7a7f750b5648642586ba7206999650208dbe5afbcc5284bcec6579c9b91"},
+    {file = "aiohttp-3.11.10-cp310-cp310-win_amd64.whl", hash = "sha256:68ff6f48b51bd78ea92b31079817aff539f6c8fc80b6b8d6ca347d7c02384e33"},
+    {file = "aiohttp-3.11.10-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:77c4aa15a89847b9891abf97f3d4048f3c2d667e00f8a623c89ad2dccee6771b"},
+    {file = "aiohttp-3.11.10-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:909af95a72cedbefe5596f0bdf3055740f96c1a4baa0dd11fd74ca4de0b4e3f1"},
+    {file = "aiohttp-3.11.10-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:386fbe79863eb564e9f3615b959e28b222259da0c48fd1be5929ac838bc65683"},
+    {file = "aiohttp-3.11.10-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3de34936eb1a647aa919655ff8d38b618e9f6b7f250cc19a57a4bf7fd2062b6d"},
+    {file = "aiohttp-3.11.10-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0c9527819b29cd2b9f52033e7fb9ff08073df49b4799c89cb5754624ecd98299"},
+    {file = "aiohttp-3.11.10-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65a96e3e03300b41f261bbfd40dfdbf1c301e87eab7cd61c054b1f2e7c89b9e8"},
+    {file = "aiohttp-3.11.10-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98f5635f7b74bcd4f6f72fcd85bea2154b323a9f05226a80bc7398d0c90763b0"},
+    {file = "aiohttp-3.11.10-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:03b6002e20938fc6ee0918c81d9e776bebccc84690e2b03ed132331cca065ee5"},
+    {file = "aiohttp-3.11.10-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6362cc6c23c08d18ddbf0e8c4d5159b5df74fea1a5278ff4f2c79aed3f4e9f46"},
+    {file = "aiohttp-3.11.10-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:3691ed7726fef54e928fe26344d930c0c8575bc968c3e239c2e1a04bd8cf7838"},
+    {file = "aiohttp-3.11.10-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:31d5093d3acd02b31c649d3a69bb072d539d4c7659b87caa4f6d2bcf57c2fa2b"},
+    {file = "aiohttp-3.11.10-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:8b3cf2dc0f0690a33f2d2b2cb15db87a65f1c609f53c37e226f84edb08d10f52"},
+    {file = "aiohttp-3.11.10-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:fbbaea811a2bba171197b08eea288b9402faa2bab2ba0858eecdd0a4105753a3"},
+    {file = "aiohttp-3.11.10-cp311-cp311-win32.whl", hash = "sha256:4b2c7ac59c5698a7a8207ba72d9e9c15b0fc484a560be0788b31312c2c5504e4"},
+    {file = "aiohttp-3.11.10-cp311-cp311-win_amd64.whl", hash = "sha256:974d3a2cce5fcfa32f06b13ccc8f20c6ad9c51802bb7f829eae8a1845c4019ec"},
+    {file = "aiohttp-3.11.10-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b78f053a7ecfc35f0451d961dacdc671f4bcbc2f58241a7c820e9d82559844cf"},
+    {file = "aiohttp-3.11.10-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ab7485222db0959a87fbe8125e233b5a6f01f4400785b36e8a7878170d8c3138"},
+    {file = "aiohttp-3.11.10-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cf14627232dfa8730453752e9cdc210966490992234d77ff90bc8dc0dce361d5"},
+    {file = "aiohttp-3.11.10-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:076bc454a7e6fd646bc82ea7f98296be0b1219b5e3ef8a488afbdd8e81fbac50"},
+    {file = "aiohttp-3.11.10-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:482cafb7dc886bebeb6c9ba7925e03591a62ab34298ee70d3dd47ba966370d2c"},
+    {file = "aiohttp-3.11.10-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bf3d1a519a324af764a46da4115bdbd566b3c73fb793ffb97f9111dbc684fc4d"},
+    {file = "aiohttp-3.11.10-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24213ba85a419103e641e55c27dc7ff03536c4873470c2478cce3311ba1eee7b"},
+    {file = "aiohttp-3.11.10-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b99acd4730ad1b196bfb03ee0803e4adac371ae8efa7e1cbc820200fc5ded109"},
+    {file = "aiohttp-3.11.10-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:14cdb5a9570be5a04eec2ace174a48ae85833c2aadc86de68f55541f66ce42ab"},
+    {file = "aiohttp-3.11.10-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:7e97d622cb083e86f18317282084bc9fbf261801b0192c34fe4b1febd9f7ae69"},
+    {file = "aiohttp-3.11.10-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:012f176945af138abc10c4a48743327a92b4ca9adc7a0e078077cdb5dbab7be0"},
+    {file = "aiohttp-3.11.10-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:44224d815853962f48fe124748227773acd9686eba6dc102578defd6fc99e8d9"},
+    {file = "aiohttp-3.11.10-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c87bf31b7fdab94ae3adbe4a48e711bfc5f89d21cf4c197e75561def39e223bc"},
+    {file = "aiohttp-3.11.10-cp312-cp312-win32.whl", hash = "sha256:06a8e2ee1cbac16fe61e51e0b0c269400e781b13bcfc33f5425912391a542985"},
+    {file = "aiohttp-3.11.10-cp312-cp312-win_amd64.whl", hash = "sha256:be2b516f56ea883a3e14dda17059716593526e10fb6303189aaf5503937db408"},
+    {file = "aiohttp-3.11.10-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8cc5203b817b748adccb07f36390feb730b1bc5f56683445bfe924fc270b8816"},
+    {file = "aiohttp-3.11.10-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ef359ebc6949e3a34c65ce20230fae70920714367c63afd80ea0c2702902ccf"},
+    {file = "aiohttp-3.11.10-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9bca390cb247dbfaec3c664326e034ef23882c3f3bfa5fbf0b56cad0320aaca5"},
+    {file = "aiohttp-3.11.10-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:811f23b3351ca532af598405db1093f018edf81368e689d1b508c57dcc6b6a32"},
+    {file = "aiohttp-3.11.10-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ddf5f7d877615f6a1e75971bfa5ac88609af3b74796ff3e06879e8422729fd01"},
+    {file = "aiohttp-3.11.10-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6ab29b8a0beb6f8eaf1e5049252cfe74adbaafd39ba91e10f18caeb0e99ffb34"},
+    {file = "aiohttp-3.11.10-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c49a76c1038c2dd116fa443eba26bbb8e6c37e924e2513574856de3b6516be99"},
+    {file = "aiohttp-3.11.10-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7f3dc0e330575f5b134918976a645e79adf333c0a1439dcf6899a80776c9ab39"},
+    {file = "aiohttp-3.11.10-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:efb15a17a12497685304b2d976cb4939e55137df7b09fa53f1b6a023f01fcb4e"},
+    {file = "aiohttp-3.11.10-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:db1d0b28fcb7f1d35600150c3e4b490775251dea70f894bf15c678fdd84eda6a"},
+    {file = "aiohttp-3.11.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:15fccaf62a4889527539ecb86834084ecf6e9ea70588efde86e8bc775e0e7542"},
+    {file = "aiohttp-3.11.10-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:593c114a2221444f30749cc5e5f4012488f56bd14de2af44fe23e1e9894a9c60"},
+    {file = "aiohttp-3.11.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7852bbcb4d0d2f0c4d583f40c3bc750ee033265d80598d0f9cb6f372baa6b836"},
+    {file = "aiohttp-3.11.10-cp313-cp313-win32.whl", hash = "sha256:65e55ca7debae8faaffee0ebb4b47a51b4075f01e9b641c31e554fd376595c6c"},
+    {file = "aiohttp-3.11.10-cp313-cp313-win_amd64.whl", hash = "sha256:beb39a6d60a709ae3fb3516a1581777e7e8b76933bb88c8f4420d875bb0267c6"},
+    {file = "aiohttp-3.11.10-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:0580f2e12de2138f34debcd5d88894786453a76e98febaf3e8fe5db62d01c9bf"},
+    {file = "aiohttp-3.11.10-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a55d2ad345684e7c3dd2c20d2f9572e9e1d5446d57200ff630e6ede7612e307f"},
+    {file = "aiohttp-3.11.10-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:04814571cb72d65a6899db6099e377ed00710bf2e3eafd2985166f2918beaf59"},
+    {file = "aiohttp-3.11.10-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e44a9a3c053b90c6f09b1bb4edd880959f5328cf63052503f892c41ea786d99f"},
+    {file = "aiohttp-3.11.10-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:502a1464ccbc800b4b1995b302efaf426e8763fadf185e933c2931df7db9a199"},
+    {file = "aiohttp-3.11.10-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:613e5169f8ae77b1933e42e418a95931fb4867b2991fc311430b15901ed67079"},
+    {file = "aiohttp-3.11.10-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4cca22a61b7fe45da8fc73c3443150c3608750bbe27641fc7558ec5117b27fdf"},
+    {file = "aiohttp-3.11.10-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:86a5dfcc39309470bd7b68c591d84056d195428d5d2e0b5ccadfbaf25b026ebc"},
+    {file = "aiohttp-3.11.10-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:77ae58586930ee6b2b6f696c82cf8e78c8016ec4795c53e36718365f6959dc82"},
+    {file = "aiohttp-3.11.10-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:78153314f26d5abef3239b4a9af20c229c6f3ecb97d4c1c01b22c4f87669820c"},
+    {file = "aiohttp-3.11.10-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:98283b94cc0e11c73acaf1c9698dea80c830ca476492c0fe2622bd931f34b487"},
+    {file = "aiohttp-3.11.10-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:53bf2097e05c2accc166c142a2090e4c6fd86581bde3fd9b2d3f9e93dda66ac1"},
+    {file = "aiohttp-3.11.10-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c5532f0441fc09c119e1dca18fbc0687e64fbeb45aa4d6a87211ceaee50a74c4"},
+    {file = "aiohttp-3.11.10-cp39-cp39-win32.whl", hash = "sha256:47ad15a65fb41c570cd0ad9a9ff8012489e68176e7207ec7b82a0940dddfd8be"},
+    {file = "aiohttp-3.11.10-cp39-cp39-win_amd64.whl", hash = "sha256:c6b9e6d7e41656d78e37ce754813fa44b455c3d0d0dced2a047def7dc5570b74"},
+    {file = "aiohttp-3.11.10.tar.gz", hash = "sha256:b1fc6b45010a8d0ff9e88f9f2418c6fd408c99c211257334aff41597ebece42e"},
 ]
 
 [package.dependencies]
@@ -161,24 +161,6 @@ test = ["anyio[trio]", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=
 trio = ["trio (<0.22)"]
 
 [[package]]
-name = "asgiref"
-version = "3.8.1"
-description = "ASGI specs, helper code, and adapters"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "asgiref-3.8.1-py3-none-any.whl", hash = "sha256:3e1e3ecc849832fe52ccf2cb6686b7a55f82bb1d6aee72a58826471390335e47"},
-    {file = "asgiref-3.8.1.tar.gz", hash = "sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590"},
-]
-
-[package.dependencies]
-typing-extensions = {version = ">=4", markers = "python_version < \"3.11\""}
-
-[package.extras]
-tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
-
-[[package]]
 name = "async-generator"
 version = "1.10"
 description = "Async generators and context managers for Python 3.5+"
@@ -205,14 +187,14 @@ files = [
 
 [[package]]
 name = "atlassian-python-api"
-version = "3.41.18"
+version = "3.41.16"
 description = "Python Atlassian REST API Wrapper"
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "atlassian_python_api-3.41.18-py3-none-any.whl", hash = "sha256:90e8b5fe649ace4967906552777203cf7d2d941688abb1da6b72c0f9a966038a"},
-    {file = "atlassian_python_api-3.41.18.tar.gz", hash = "sha256:f38fa9c9c39fc072fa2124d2a8c9db3b684cb88797f428ddac19ae3c94d70bb3"},
+    {file = "atlassian_python_api-3.41.16-py3-none-any.whl", hash = "sha256:99e5587233a96d22c45a61b19523dd98e8266c620ba2d289f23e4ea35c9cf316"},
+    {file = "atlassian_python_api-3.41.16.tar.gz", hash = "sha256:dc0144ff8b8884562bb2af650586292524ad25f120cd21940df80f0d2ac64411"},
 ]
 
 [package.dependencies]
@@ -221,7 +203,7 @@ deprecated = "*"
 jmespath = "*"
 oauthlib = "*"
 requests = "*"
-requests_oauthlib = "*"
+requests-oauthlib = "*"
 six = "*"
 
 [package.extras]
@@ -229,20 +211,20 @@ kerberos = ["requests-kerberos"]
 
 [[package]]
 name = "attrs"
-version = "24.3.0"
+version = "24.2.0"
 description = "Classes Without Boilerplate"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "attrs-24.3.0-py3-none-any.whl", hash = "sha256:ac96cd038792094f438ad1f6ff80837353805ac950cd2aa0e0625ef19850c308"},
-    {file = "attrs-24.3.0.tar.gz", hash = "sha256:8f5c07333d543103541ba7be0e2ce16eeee8130cb0b3f9238ab904ce1e85baff"},
+    {file = "attrs-24.2.0-py3-none-any.whl", hash = "sha256:81921eb96de3191c8258c199618104dd27ac608d9366f5e35d011eae1867ede2"},
+    {file = "attrs-24.2.0.tar.gz", hash = "sha256:5cfb1b9148b5b086569baec03f20d7b6bf3bcacc9a42bebf87ffaaca362f6346"},
 ]
 
 [package.extras]
 benchmark = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-codspeed", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 cov = ["cloudpickle", "coverage[toml] (>=5.3)", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
-dev = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pre-commit-uv", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
+dev = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 docs = ["cogapp", "furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
 tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
@@ -270,15 +252,27 @@ html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
+name = "cachetools"
+version = "5.5.0"
+description = "Extensible memoizing collections and decorators"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "cachetools-5.5.0-py3-none-any.whl", hash = "sha256:02134e8439cdc2ffb62023ce1debca2944c3f289d66bb17ead3ab3dede74b292"},
+    {file = "cachetools-5.5.0.tar.gz", hash = "sha256:2cc24fb4cbe39633fb7badd9db9ca6295d766d9c2995f245725a46715d050f2a"},
+]
+
+[[package]]
 name = "certifi"
-version = "2024.12.14"
+version = "2024.8.30"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
 files = [
-    {file = "certifi-2024.12.14-py3-none-any.whl", hash = "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56"},
-    {file = "certifi-2024.12.14.tar.gz", hash = "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db"},
+    {file = "certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8"},
+    {file = "certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9"},
 ]
 
 [[package]]
@@ -362,105 +356,130 @@ files = [
 pycparser = "*"
 
 [[package]]
-name = "charset-normalizer"
-version = "3.4.1"
-description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+name = "chardet"
+version = "5.2.0"
+description = "Universal encoding detector for Python 3"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "charset_normalizer-3.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:91b36a978b5ae0ee86c394f5a54d6ef44db1de0815eb43de826d41d21e4af3de"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7461baadb4dc00fd9e0acbe254e3d7d2112e7f92ced2adc96e54ef6501c5f176"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e218488cd232553829be0664c2292d3af2eeeb94b32bea483cf79ac6a694e037"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:80ed5e856eb7f30115aaf94e4a08114ccc8813e6ed1b5efa74f9f82e8509858f"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b010a7a4fd316c3c484d482922d13044979e78d1861f0e0650423144c616a46a"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4532bff1b8421fd0a320463030c7520f56a79c9024a4e88f01c537316019005a"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d973f03c0cb71c5ed99037b870f2be986c3c05e63622c017ea9816881d2dd247"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3a3bd0dcd373514dcec91c411ddb9632c0d7d92aed7093b8c3bbb6d69ca74408"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:d9c3cdf5390dcd29aa8056d13e8e99526cda0305acc038b96b30352aff5ff2bb"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:2bdfe3ac2e1bbe5b59a1a63721eb3b95fc9b6817ae4a46debbb4e11f6232428d"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:eab677309cdb30d047996b36d34caeda1dc91149e4fdca0b1a039b3f79d9a807"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-win32.whl", hash = "sha256:c0429126cf75e16c4f0ad00ee0eae4242dc652290f940152ca8c75c3a4b6ee8f"},
-    {file = "charset_normalizer-3.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:9f0b8b1c6d84c8034a44893aba5e767bf9c7a211e313a9605d9c617d7083829f"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8bfa33f4f2672964266e940dd22a195989ba31669bd84629f05fab3ef4e2d125"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28bf57629c75e810b6ae989f03c0828d64d6b26a5e205535585f96093e405ed1"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f08ff5e948271dc7e18a35641d2f11a4cd8dfd5634f55228b691e62b37125eb3"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:234ac59ea147c59ee4da87a0c0f098e9c8d169f4dc2a159ef720f1a61bbe27cd"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd4ec41f914fa74ad1b8304bbc634b3de73d2a0889bd32076342a573e0779e00"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eea6ee1db730b3483adf394ea72f808b6e18cf3cb6454b4d86e04fa8c4327a12"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c96836c97b1238e9c9e3fe90844c947d5afbf4f4c92762679acfe19927d81d77"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4d86f7aff21ee58f26dcf5ae81a9addbd914115cdebcbb2217e4f0ed8982e146"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:09b5e6733cbd160dcc09589227187e242a30a49ca5cefa5a7edd3f9d19ed53fd"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:5777ee0881f9499ed0f71cc82cf873d9a0ca8af166dfa0af8ec4e675b7df48e6"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:237bdbe6159cff53b4f24f397d43c6336c6b0b42affbe857970cefbb620911c8"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-win32.whl", hash = "sha256:8417cb1f36cc0bc7eaba8ccb0e04d55f0ee52df06df3ad55259b9a323555fc8b"},
-    {file = "charset_normalizer-3.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:d7f50a1f8c450f3925cb367d011448c39239bb3eb4117c36a6d354794de4ce76"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:73d94b58ec7fecbc7366247d3b0b10a21681004153238750bb67bd9012414545"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dad3e487649f498dd991eeb901125411559b22e8d7ab25d3aeb1af367df5efd7"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c30197aa96e8eed02200a83fba2657b4c3acd0f0aa4bdc9f6c1af8e8962e0757"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2369eea1ee4a7610a860d88f268eb39b95cb588acd7235e02fd5a5601773d4fa"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc2722592d8998c870fa4e290c2eec2c1569b87fe58618e67d38b4665dfa680d"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffc9202a29ab3920fa812879e95a9e78b2465fd10be7fcbd042899695d75e616"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:804a4d582ba6e5b747c625bf1255e6b1507465494a40a2130978bda7b932c90b"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0f55e69f030f7163dffe9fd0752b32f070566451afe180f99dbeeb81f511ad8d"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c4c3e6da02df6fa1410a7680bd3f63d4f710232d3139089536310d027950696a"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:5df196eb874dae23dcfb968c83d4f8fdccb333330fe1fc278ac5ceeb101003a9"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e358e64305fe12299a08e08978f51fc21fac060dcfcddd95453eabe5b93ed0e1"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-win32.whl", hash = "sha256:9b23ca7ef998bc739bf6ffc077c2116917eabcc901f88da1b9856b210ef63f35"},
-    {file = "charset_normalizer-3.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ff8a4a60c227ad87030d76e99cd1698345d4491638dfa6673027c48b3cd395f"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:aabfa34badd18f1da5ec1bc2715cadc8dca465868a4e73a0173466b688f29dda"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22e14b5d70560b8dd51ec22863f370d1e595ac3d024cb8ad7d308b4cd95f8313"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8436c508b408b82d87dc5f62496973a1805cd46727c34440b0d29d8a2f50a6c9"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2d074908e1aecee37a7635990b2c6d504cd4766c7bc9fc86d63f9c09af3fa11b"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:955f8851919303c92343d2f66165294848d57e9bba6cf6e3625485a70a038d11"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:44ecbf16649486d4aebafeaa7ec4c9fed8b88101f4dd612dcaf65d5e815f837f"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0924e81d3d5e70f8126529951dac65c1010cdf117bb75eb02dd12339b57749dd"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2967f74ad52c3b98de4c3b32e1a44e32975e008a9cd2a8cc8966d6a5218c5cb2"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c75cb2a3e389853835e84a2d8fb2b81a10645b503eca9bcb98df6b5a43eb8886"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:09b26ae6b1abf0d27570633b2b078a2a20419c99d66fb2823173d73f188ce601"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa88b843d6e211393a37219e6a1c1df99d35e8fd90446f1118f4216e307e48cd"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-win32.whl", hash = "sha256:eb8178fe3dba6450a3e024e95ac49ed3400e506fd4e9e5c32d30adda88cbd407"},
-    {file = "charset_normalizer-3.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:b1ac5992a838106edb89654e0aebfc24f5848ae2547d22c2c3f66454daa11971"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f30bf9fd9be89ecb2360c7d94a711f00c09b976258846efe40db3d05828e8089"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:97f68b8d6831127e4787ad15e6757232e14e12060bec17091b85eb1486b91d8d"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7974a0b5ecd505609e3b19742b60cee7aa2aa2fb3151bc917e6e2646d7667dcf"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc54db6c8593ef7d4b2a331b58653356cf04f67c960f584edb7c3d8c97e8f39e"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:311f30128d7d333eebd7896965bfcfbd0065f1716ec92bd5638d7748eb6f936a"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:7d053096f67cd1241601111b698f5cad775f97ab25d81567d3f59219b5f1adbd"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-musllinux_1_2_i686.whl", hash = "sha256:807f52c1f798eef6cf26beb819eeb8819b1622ddfeef9d0977a8502d4db6d534"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-musllinux_1_2_ppc64le.whl", hash = "sha256:dccbe65bd2f7f7ec22c4ff99ed56faa1e9f785482b9bbd7c717e26fd723a1d1e"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-musllinux_1_2_s390x.whl", hash = "sha256:2fb9bd477fdea8684f78791a6de97a953c51831ee2981f8e4f583ff3b9d9687e"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:01732659ba9b5b873fc117534143e4feefecf3b2078b0a6a2e925271bb6f4cfa"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-win32.whl", hash = "sha256:7a4f97a081603d2050bfaffdefa5b02a9ec823f8348a572e39032caa8404a487"},
-    {file = "charset_normalizer-3.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:7b1bef6280950ee6c177b326508f86cad7ad4dff12454483b51d8b7d673a2c5d"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:ecddf25bee22fe4fe3737a399d0d177d72bc22be6913acfab364b40bce1ba83c"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c60ca7339acd497a55b0ea5d506b2a2612afb2826560416f6894e8b5770d4a9"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b7b2d86dd06bfc2ade3312a83a5c364c7ec2e3498f8734282c6c3d4b07b346b8"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dd78cfcda14a1ef52584dbb008f7ac81c1328c0f58184bf9a84c49c605002da6"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6e27f48bcd0957c6d4cb9d6fa6b61d192d0b13d5ef563e5f2ae35feafc0d179c"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:01ad647cdd609225c5350561d084b42ddf732f4eeefe6e678765636791e78b9a"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:619a609aa74ae43d90ed2e89bdd784765de0a25ca761b93e196d938b8fd1dbbd"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:89149166622f4db9b4b6a449256291dc87a99ee53151c74cbd82a53c8c2f6ccd"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:7709f51f5f7c853f0fb938bcd3bc59cdfdc5203635ffd18bf354f6967ea0f824"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:345b0426edd4e18138d6528aed636de7a9ed169b4aaf9d61a8c19e39d26838ca"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:0907f11d019260cdc3f94fbdb23ff9125f6b5d1039b76003b5b0ac9d6a6c9d5b"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-win32.whl", hash = "sha256:ea0d8d539afa5eb2728aa1932a988a9a7af94f18582ffae4bc10b3fbdad0626e"},
-    {file = "charset_normalizer-3.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:329ce159e82018d646c7ac45b01a430369d526569ec08516081727a20e9e4af4"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b97e690a2118911e39b4042088092771b4ae3fc3aa86518f84b8cf6888dbdb41"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:78baa6d91634dfb69ec52a463534bc0df05dbd546209b79a3880a34487f4b84f"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1a2bc9f351a75ef49d664206d51f8e5ede9da246602dc2d2726837620ea034b2"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75832c08354f595c760a804588b9357d34ec00ba1c940c15e31e96d902093770"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0af291f4fe114be0280cdd29d533696a77b5b49cfde5467176ecab32353395c4"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0167ddc8ab6508fe81860a57dd472b2ef4060e8d378f0cc555707126830f2537"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:2a75d49014d118e4198bcee5ee0a6f25856b29b12dbf7cd012791f8a6cc5c496"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:363e2f92b0f0174b2f8238240a1a30142e3db7b957a5dd5689b0e75fb717cc78"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:ab36c8eb7e454e34e60eb55ca5d241a5d18b2c6244f6827a30e451c42410b5f7"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:4c0907b1928a36d5a998d72d64d8eaa7244989f7aaaf947500d3a800c83a3fd6"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:04432ad9479fa40ec0f387795ddad4437a2b50417c69fa275e212933519ff294"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-win32.whl", hash = "sha256:3bed14e9c89dcb10e8f3a29f9ccac4955aebe93c71ae803af79265c9ca5644c5"},
-    {file = "charset_normalizer-3.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:49402233c892a461407c512a19435d1ce275543138294f7ef013f0b63d5d3765"},
-    {file = "charset_normalizer-3.4.1-py3-none-any.whl", hash = "sha256:d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85"},
-    {file = "charset_normalizer-3.4.1.tar.gz", hash = "sha256:44251f18cd68a75b56585dd00dae26183e102cd5e0f9f1466e6df5da2ed64ea3"},
+    {file = "chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"},
+    {file = "chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"},
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.0"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+optional = false
+python-versions = ">=3.7.0"
+groups = ["main"]
+files = [
+    {file = "charset_normalizer-3.4.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:4f9fc98dad6c2eaa32fc3af1417d95b5e3d08aff968df0cd320066def971f9a6"},
+    {file = "charset_normalizer-3.4.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0de7b687289d3c1b3e8660d0741874abe7888100efe14bd0f9fd7141bcbda92b"},
+    {file = "charset_normalizer-3.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5ed2e36c3e9b4f21dd9422f6893dec0abf2cca553af509b10cd630f878d3eb99"},
+    {file = "charset_normalizer-3.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40d3ff7fc90b98c637bda91c89d51264a3dcf210cade3a2c6f838c7268d7a4ca"},
+    {file = "charset_normalizer-3.4.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1110e22af8ca26b90bd6364fe4c763329b0ebf1ee213ba32b68c73de5752323d"},
+    {file = "charset_normalizer-3.4.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86f4e8cca779080f66ff4f191a685ced73d2f72d50216f7112185dc02b90b9b7"},
+    {file = "charset_normalizer-3.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f683ddc7eedd742e2889d2bfb96d69573fde1d92fcb811979cdb7165bb9c7d3"},
+    {file = "charset_normalizer-3.4.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:27623ba66c183eca01bf9ff833875b459cad267aeeb044477fedac35e19ba907"},
+    {file = "charset_normalizer-3.4.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f606a1881d2663630ea5b8ce2efe2111740df4b687bd78b34a8131baa007f79b"},
+    {file = "charset_normalizer-3.4.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0b309d1747110feb25d7ed6b01afdec269c647d382c857ef4663bbe6ad95a912"},
+    {file = "charset_normalizer-3.4.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:136815f06a3ae311fae551c3df1f998a1ebd01ddd424aa5603a4336997629e95"},
+    {file = "charset_normalizer-3.4.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:14215b71a762336254351b00ec720a8e85cada43b987da5a042e4ce3e82bd68e"},
+    {file = "charset_normalizer-3.4.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:79983512b108e4a164b9c8d34de3992f76d48cadc9554c9e60b43f308988aabe"},
+    {file = "charset_normalizer-3.4.0-cp310-cp310-win32.whl", hash = "sha256:c94057af19bc953643a33581844649a7fdab902624d2eb739738a30e2b3e60fc"},
+    {file = "charset_normalizer-3.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:55f56e2ebd4e3bc50442fbc0888c9d8c94e4e06a933804e2af3e89e2f9c1c749"},
+    {file = "charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0d99dd8ff461990f12d6e42c7347fd9ab2532fb70e9621ba520f9e8637161d7c"},
+    {file = "charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c57516e58fd17d03ebe67e181a4e4e2ccab1168f8c2976c6a334d4f819fe5944"},
+    {file = "charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6dba5d19c4dfab08e58d5b36304b3f92f3bd5d42c1a3fa37b5ba5cdf6dfcbcee"},
+    {file = "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf4475b82be41b07cc5e5ff94810e6a01f276e37c2d55571e3fe175e467a1a1c"},
+    {file = "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce031db0408e487fd2775d745ce30a7cd2923667cf3b69d48d219f1d8f5ddeb6"},
+    {file = "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8ff4e7cdfdb1ab5698e675ca622e72d58a6fa2a8aa58195de0c0061288e6e3ea"},
+    {file = "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3710a9751938947e6327ea9f3ea6332a09bf0ba0c09cae9cb1f250bd1f1549bc"},
+    {file = "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:82357d85de703176b5587dbe6ade8ff67f9f69a41c0733cf2425378b49954de5"},
+    {file = "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47334db71978b23ebcf3c0f9f5ee98b8d65992b65c9c4f2d34c2eaf5bcaf0594"},
+    {file = "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8ce7fd6767a1cc5a92a639b391891bf1c268b03ec7e021c7d6d902285259685c"},
+    {file = "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f1a2f519ae173b5b6a2c9d5fa3116ce16e48b3462c8b96dfdded11055e3d6365"},
+    {file = "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:63bc5c4ae26e4bc6be6469943b8253c0fd4e4186c43ad46e713ea61a0ba49129"},
+    {file = "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bcb4f8ea87d03bc51ad04add8ceaf9b0f085ac045ab4d74e73bbc2dc033f0236"},
+    {file = "charset_normalizer-3.4.0-cp311-cp311-win32.whl", hash = "sha256:9ae4ef0b3f6b41bad6366fb0ea4fc1d7ed051528e113a60fa2a65a9abb5b1d99"},
+    {file = "charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:cee4373f4d3ad28f1ab6290684d8e2ebdb9e7a1b74fdc39e4c211995f77bec27"},
+    {file = "charset_normalizer-3.4.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0713f3adb9d03d49d365b70b84775d0a0d18e4ab08d12bc46baa6132ba78aaf6"},
+    {file = "charset_normalizer-3.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:de7376c29d95d6719048c194a9cf1a1b0393fbe8488a22008610b0361d834ecf"},
+    {file = "charset_normalizer-3.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4a51b48f42d9358460b78725283f04bddaf44a9358197b889657deba38f329db"},
+    {file = "charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b295729485b06c1a0683af02a9e42d2caa9db04a373dc38a6a58cdd1e8abddf1"},
+    {file = "charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ee803480535c44e7f5ad00788526da7d85525cfefaf8acf8ab9a310000be4b03"},
+    {file = "charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3d59d125ffbd6d552765510e3f31ed75ebac2c7470c7274195b9161a32350284"},
+    {file = "charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8cda06946eac330cbe6598f77bb54e690b4ca93f593dee1568ad22b04f347c15"},
+    {file = "charset_normalizer-3.4.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07afec21bbbbf8a5cc3651aa96b980afe2526e7f048fdfb7f1014d84acc8b6d8"},
+    {file = "charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6b40e8d38afe634559e398cc32b1472f376a4099c75fe6299ae607e404c033b2"},
+    {file = "charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:b8dcd239c743aa2f9c22ce674a145e0a25cb1566c495928440a181ca1ccf6719"},
+    {file = "charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:84450ba661fb96e9fd67629b93d2941c871ca86fc38d835d19d4225ff946a631"},
+    {file = "charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:44aeb140295a2f0659e113b31cfe92c9061622cadbc9e2a2f7b8ef6b1e29ef4b"},
+    {file = "charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1db4e7fefefd0f548d73e2e2e041f9df5c59e178b4c72fbac4cc6f535cfb1565"},
+    {file = "charset_normalizer-3.4.0-cp312-cp312-win32.whl", hash = "sha256:5726cf76c982532c1863fb64d8c6dd0e4c90b6ece9feb06c9f202417a31f7dd7"},
+    {file = "charset_normalizer-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:b197e7094f232959f8f20541ead1d9862ac5ebea1d58e9849c1bf979255dfac9"},
+    {file = "charset_normalizer-3.4.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dd4eda173a9fcccb5f2e2bd2a9f423d180194b1bf17cf59e3269899235b2a114"},
+    {file = "charset_normalizer-3.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e9e3c4c9e1ed40ea53acf11e2a386383c3304212c965773704e4603d589343ed"},
+    {file = "charset_normalizer-3.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:92a7e36b000bf022ef3dbb9c46bfe2d52c047d5e3f3343f43204263c5addc250"},
+    {file = "charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54b6a92d009cbe2fb11054ba694bc9e284dad30a26757b1e372a1fdddaf21920"},
+    {file = "charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ffd9493de4c922f2a38c2bf62b831dcec90ac673ed1ca182fe11b4d8e9f2a64"},
+    {file = "charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:35c404d74c2926d0287fbd63ed5d27eb911eb9e4a3bb2c6d294f3cfd4a9e0c23"},
+    {file = "charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4796efc4faf6b53a18e3d46343535caed491776a22af773f366534056c4e1fbc"},
+    {file = "charset_normalizer-3.4.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e7fdd52961feb4c96507aa649550ec2a0d527c086d284749b2f582f2d40a2e0d"},
+    {file = "charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:92db3c28b5b2a273346bebb24857fda45601aef6ae1c011c0a997106581e8a88"},
+    {file = "charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ab973df98fc99ab39080bfb0eb3a925181454d7c3ac8a1e695fddfae696d9e90"},
+    {file = "charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4b67fdab07fdd3c10bb21edab3cbfe8cf5696f453afce75d815d9d7223fbe88b"},
+    {file = "charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:aa41e526a5d4a9dfcfbab0716c7e8a1b215abd3f3df5a45cf18a12721d31cb5d"},
+    {file = "charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ffc519621dce0c767e96b9c53f09c5d215578e10b02c285809f76509a3931482"},
+    {file = "charset_normalizer-3.4.0-cp313-cp313-win32.whl", hash = "sha256:f19c1585933c82098c2a520f8ec1227f20e339e33aca8fa6f956f6691b784e67"},
+    {file = "charset_normalizer-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:707b82d19e65c9bd28b81dde95249b07bf9f5b90ebe1ef17d9b57473f8a64b7b"},
+    {file = "charset_normalizer-3.4.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:dbe03226baf438ac4fda9e2d0715022fd579cb641c4cf639fa40d53b2fe6f3e2"},
+    {file = "charset_normalizer-3.4.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd9a8bd8900e65504a305bf8ae6fa9fbc66de94178c420791d0293702fce2df7"},
+    {file = "charset_normalizer-3.4.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b8831399554b92b72af5932cdbbd4ddc55c55f631bb13ff8fe4e6536a06c5c51"},
+    {file = "charset_normalizer-3.4.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a14969b8691f7998e74663b77b4c36c0337cb1df552da83d5c9004a93afdb574"},
+    {file = "charset_normalizer-3.4.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcaf7c1524c0542ee2fc82cc8ec337f7a9f7edee2532421ab200d2b920fc97cf"},
+    {file = "charset_normalizer-3.4.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:425c5f215d0eecee9a56cdb703203dda90423247421bf0d67125add85d0c4455"},
+    {file = "charset_normalizer-3.4.0-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:d5b054862739d276e09928de37c79ddeec42a6e1bfc55863be96a36ba22926f6"},
+    {file = "charset_normalizer-3.4.0-cp37-cp37m-musllinux_1_2_i686.whl", hash = "sha256:f3e73a4255342d4eb26ef6df01e3962e73aa29baa3124a8e824c5d3364a65748"},
+    {file = "charset_normalizer-3.4.0-cp37-cp37m-musllinux_1_2_ppc64le.whl", hash = "sha256:2f6c34da58ea9c1a9515621f4d9ac379871a8f21168ba1b5e09d74250de5ad62"},
+    {file = "charset_normalizer-3.4.0-cp37-cp37m-musllinux_1_2_s390x.whl", hash = "sha256:f09cb5a7bbe1ecae6e87901a2eb23e0256bb524a79ccc53eb0b7629fbe7677c4"},
+    {file = "charset_normalizer-3.4.0-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:0099d79bdfcf5c1f0c2c72f91516702ebf8b0b8ddd8905f97a8aecf49712c621"},
+    {file = "charset_normalizer-3.4.0-cp37-cp37m-win32.whl", hash = "sha256:9c98230f5042f4945f957d006edccc2af1e03ed5e37ce7c373f00a5a4daa6149"},
+    {file = "charset_normalizer-3.4.0-cp37-cp37m-win_amd64.whl", hash = "sha256:62f60aebecfc7f4b82e3f639a7d1433a20ec32824db2199a11ad4f5e146ef5ee"},
+    {file = "charset_normalizer-3.4.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:af73657b7a68211996527dbfeffbb0864e043d270580c5aef06dc4b659a4b578"},
+    {file = "charset_normalizer-3.4.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cab5d0b79d987c67f3b9e9c53f54a61360422a5a0bc075f43cab5621d530c3b6"},
+    {file = "charset_normalizer-3.4.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9289fd5dddcf57bab41d044f1756550f9e7cf0c8e373b8cdf0ce8773dc4bd417"},
+    {file = "charset_normalizer-3.4.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b493a043635eb376e50eedf7818f2f322eabbaa974e948bd8bdd29eb7ef2a51"},
+    {file = "charset_normalizer-3.4.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9fa2566ca27d67c86569e8c85297aaf413ffab85a8960500f12ea34ff98e4c41"},
+    {file = "charset_normalizer-3.4.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a8e538f46104c815be19c975572d74afb53f29650ea2025bbfaef359d2de2f7f"},
+    {file = "charset_normalizer-3.4.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6fd30dc99682dc2c603c2b315bded2799019cea829f8bf57dc6b61efde6611c8"},
+    {file = "charset_normalizer-3.4.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2006769bd1640bdf4d5641c69a3d63b71b81445473cac5ded39740a226fa88ab"},
+    {file = "charset_normalizer-3.4.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:dc15e99b2d8a656f8e666854404f1ba54765871104e50c8e9813af8a7db07f12"},
+    {file = "charset_normalizer-3.4.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:ab2e5bef076f5a235c3774b4f4028a680432cded7cad37bba0fd90d64b187d19"},
+    {file = "charset_normalizer-3.4.0-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:4ec9dd88a5b71abfc74e9df5ebe7921c35cbb3b641181a531ca65cdb5e8e4dea"},
+    {file = "charset_normalizer-3.4.0-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:43193c5cda5d612f247172016c4bb71251c784d7a4d9314677186a838ad34858"},
+    {file = "charset_normalizer-3.4.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:aa693779a8b50cd97570e5a0f343538a8dbd3e496fa5dcb87e29406ad0299654"},
+    {file = "charset_normalizer-3.4.0-cp38-cp38-win32.whl", hash = "sha256:7706f5850360ac01d80c89bcef1640683cc12ed87f42579dab6c5d3ed6888613"},
+    {file = "charset_normalizer-3.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:c3e446d253bd88f6377260d07c895816ebf33ffffd56c1c792b13bff9c3e1ade"},
+    {file = "charset_normalizer-3.4.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:980b4f289d1d90ca5efcf07958d3eb38ed9c0b7676bf2831a54d4f66f9c27dfa"},
+    {file = "charset_normalizer-3.4.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f28f891ccd15c514a0981f3b9db9aa23d62fe1a99997512b0491d2ed323d229a"},
+    {file = "charset_normalizer-3.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8aacce6e2e1edcb6ac625fb0f8c3a9570ccc7bfba1f63419b3769ccf6a00ed0"},
+    {file = "charset_normalizer-3.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd7af3717683bea4c87acd8c0d3d5b44d56120b26fd3f8a692bdd2d5260c620a"},
+    {file = "charset_normalizer-3.4.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5ff2ed8194587faf56555927b3aa10e6fb69d931e33953943bc4f837dfee2242"},
+    {file = "charset_normalizer-3.4.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e91f541a85298cf35433bf66f3fab2a4a2cff05c127eeca4af174f6d497f0d4b"},
+    {file = "charset_normalizer-3.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309a7de0a0ff3040acaebb35ec45d18db4b28232f21998851cfa709eeff49d62"},
+    {file = "charset_normalizer-3.4.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:285e96d9d53422efc0d7a17c60e59f37fbf3dfa942073f666db4ac71e8d726d0"},
+    {file = "charset_normalizer-3.4.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:5d447056e2ca60382d460a604b6302d8db69476fd2015c81e7c35417cfabe4cd"},
+    {file = "charset_normalizer-3.4.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:20587d20f557fe189b7947d8e7ec5afa110ccf72a3128d61a2a387c3313f46be"},
+    {file = "charset_normalizer-3.4.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:130272c698667a982a5d0e626851ceff662565379baf0ff2cc58067b81d4f11d"},
+    {file = "charset_normalizer-3.4.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:ab22fbd9765e6954bc0bcff24c25ff71dcbfdb185fcdaca49e81bac68fe724d3"},
+    {file = "charset_normalizer-3.4.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:7782afc9b6b42200f7362858f9e73b1f8316afb276d316336c0ec3bd73312742"},
+    {file = "charset_normalizer-3.4.0-cp39-cp39-win32.whl", hash = "sha256:2de62e8801ddfff069cd5c504ce3bc9672b23266597d4e4f50eda28846c322f2"},
+    {file = "charset_normalizer-3.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:95c3c157765b031331dd4db3c775e58deaee050a3042fcad72cbc4189d7c8dca"},
+    {file = "charset_normalizer-3.4.0-py3-none-any.whl", hash = "sha256:fe9f97feb71aa9896b81973a7bbada8c49501dc73e58a10fcef6663af95e5079"},
+    {file = "charset_normalizer-3.4.0.tar.gz", hash = "sha256:223217c3d4f82c3ac5e29032b3f1c2eb0fb591b72161f86d93f5719079dae93e"},
 ]
 
 [[package]]
@@ -485,11 +504,88 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["main"]
-markers = "platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+
+[[package]]
+name = "coverage"
+version = "7.6.9"
+description = "Code coverage measurement for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "coverage-7.6.9-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:85d9636f72e8991a1706b2b55b06c27545448baf9f6dbf51c4004609aacd7dcb"},
+    {file = "coverage-7.6.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:608a7fd78c67bee8936378299a6cb9f5149bb80238c7a566fc3e6717a4e68710"},
+    {file = "coverage-7.6.9-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:96d636c77af18b5cb664ddf12dab9b15a0cfe9c0bde715da38698c8cea748bfa"},
+    {file = "coverage-7.6.9-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d75cded8a3cff93da9edc31446872d2997e327921d8eed86641efafd350e1df1"},
+    {file = "coverage-7.6.9-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7b15f589593110ae767ce997775d645b47e5cbbf54fd322f8ebea6277466cec"},
+    {file = "coverage-7.6.9-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:44349150f6811b44b25574839b39ae35291f6496eb795b7366fef3bd3cf112d3"},
+    {file = "coverage-7.6.9-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:d891c136b5b310d0e702e186d70cd16d1119ea8927347045124cb286b29297e5"},
+    {file = "coverage-7.6.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:db1dab894cc139f67822a92910466531de5ea6034ddfd2b11c0d4c6257168073"},
+    {file = "coverage-7.6.9-cp310-cp310-win32.whl", hash = "sha256:41ff7b0da5af71a51b53f501a3bac65fb0ec311ebed1632e58fc6107f03b9198"},
+    {file = "coverage-7.6.9-cp310-cp310-win_amd64.whl", hash = "sha256:35371f8438028fdccfaf3570b31d98e8d9eda8bb1d6ab9473f5a390969e98717"},
+    {file = "coverage-7.6.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:932fc826442132dde42ee52cf66d941f581c685a6313feebed358411238f60f9"},
+    {file = "coverage-7.6.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:085161be5f3b30fd9b3e7b9a8c301f935c8313dcf928a07b116324abea2c1c2c"},
+    {file = "coverage-7.6.9-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ccc660a77e1c2bf24ddbce969af9447a9474790160cfb23de6be4fa88e3951c7"},
+    {file = "coverage-7.6.9-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c69e42c892c018cd3c8d90da61d845f50a8243062b19d228189b0224150018a9"},
+    {file = "coverage-7.6.9-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0824a28ec542a0be22f60c6ac36d679e0e262e5353203bea81d44ee81fe9c6d4"},
+    {file = "coverage-7.6.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4401ae5fc52ad8d26d2a5d8a7428b0f0c72431683f8e63e42e70606374c311a1"},
+    {file = "coverage-7.6.9-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:98caba4476a6c8d59ec1eb00c7dd862ba9beca34085642d46ed503cc2d440d4b"},
+    {file = "coverage-7.6.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ee5defd1733fd6ec08b168bd4f5387d5b322f45ca9e0e6c817ea6c4cd36313e3"},
+    {file = "coverage-7.6.9-cp311-cp311-win32.whl", hash = "sha256:f2d1ec60d6d256bdf298cb86b78dd715980828f50c46701abc3b0a2b3f8a0dc0"},
+    {file = "coverage-7.6.9-cp311-cp311-win_amd64.whl", hash = "sha256:0d59fd927b1f04de57a2ba0137166d31c1a6dd9e764ad4af552912d70428c92b"},
+    {file = "coverage-7.6.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:99e266ae0b5d15f1ca8d278a668df6f51cc4b854513daab5cae695ed7b721cf8"},
+    {file = "coverage-7.6.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9901d36492009a0a9b94b20e52ebfc8453bf49bb2b27bca2c9706f8b4f5a554a"},
+    {file = "coverage-7.6.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abd3e72dd5b97e3af4246cdada7738ef0e608168de952b837b8dd7e90341f015"},
+    {file = "coverage-7.6.9-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ff74026a461eb0660366fb01c650c1d00f833a086b336bdad7ab00cc952072b3"},
+    {file = "coverage-7.6.9-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65dad5a248823a4996724a88eb51d4b31587aa7aa428562dbe459c684e5787ae"},
+    {file = "coverage-7.6.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:22be16571504c9ccea919fcedb459d5ab20d41172056206eb2994e2ff06118a4"},
+    {file = "coverage-7.6.9-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0f957943bc718b87144ecaee70762bc2bc3f1a7a53c7b861103546d3a403f0a6"},
+    {file = "coverage-7.6.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0ae1387db4aecb1f485fb70a6c0148c6cdaebb6038f1d40089b1fc84a5db556f"},
+    {file = "coverage-7.6.9-cp312-cp312-win32.whl", hash = "sha256:1a330812d9cc7ac2182586f6d41b4d0fadf9be9049f350e0efb275c8ee8eb692"},
+    {file = "coverage-7.6.9-cp312-cp312-win_amd64.whl", hash = "sha256:b12c6b18269ca471eedd41c1b6a1065b2f7827508edb9a7ed5555e9a56dcfc97"},
+    {file = "coverage-7.6.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:899b8cd4781c400454f2f64f7776a5d87bbd7b3e7f7bda0cb18f857bb1334664"},
+    {file = "coverage-7.6.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:61f70dc68bd36810972e55bbbe83674ea073dd1dcc121040a08cdf3416c5349c"},
+    {file = "coverage-7.6.9-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8a289d23d4c46f1a82d5db4abeb40b9b5be91731ee19a379d15790e53031c014"},
+    {file = "coverage-7.6.9-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7e216d8044a356fc0337c7a2a0536d6de07888d7bcda76febcb8adc50bdbbd00"},
+    {file = "coverage-7.6.9-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3c026eb44f744acaa2bda7493dad903aa5bf5fc4f2554293a798d5606710055d"},
+    {file = "coverage-7.6.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e77363e8425325384f9d49272c54045bbed2f478e9dd698dbc65dbc37860eb0a"},
+    {file = "coverage-7.6.9-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:777abfab476cf83b5177b84d7486497e034eb9eaea0d746ce0c1268c71652077"},
+    {file = "coverage-7.6.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:447af20e25fdbe16f26e84eb714ba21d98868705cb138252d28bc400381f6ffb"},
+    {file = "coverage-7.6.9-cp313-cp313-win32.whl", hash = "sha256:d872ec5aeb086cbea771c573600d47944eea2dcba8be5f3ee649bfe3cb8dc9ba"},
+    {file = "coverage-7.6.9-cp313-cp313-win_amd64.whl", hash = "sha256:fd1213c86e48dfdc5a0cc676551db467495a95a662d2396ecd58e719191446e1"},
+    {file = "coverage-7.6.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ba9e7484d286cd5a43744e5f47b0b3fb457865baf07bafc6bee91896364e1419"},
+    {file = "coverage-7.6.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e5ea1cf0872ee455c03e5674b5bca5e3e68e159379c1af0903e89f5eba9ccc3a"},
+    {file = "coverage-7.6.9-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d10e07aa2b91835d6abec555ec8b2733347956991901eea6ffac295f83a30e4"},
+    {file = "coverage-7.6.9-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:13a9e2d3ee855db3dd6ea1ba5203316a1b1fd8eaeffc37c5b54987e61e4194ae"},
+    {file = "coverage-7.6.9-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c38bf15a40ccf5619fa2fe8f26106c7e8e080d7760aeccb3722664c8656b030"},
+    {file = "coverage-7.6.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d5275455b3e4627c8e7154feaf7ee0743c2e7af82f6e3b561967b1cca755a0be"},
+    {file = "coverage-7.6.9-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:8f8770dfc6e2c6a2d4569f411015c8d751c980d17a14b0530da2d7f27ffdd88e"},
+    {file = "coverage-7.6.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8d2dfa71665a29b153a9681edb1c8d9c1ea50dfc2375fb4dac99ea7e21a0bcd9"},
+    {file = "coverage-7.6.9-cp313-cp313t-win32.whl", hash = "sha256:5e6b86b5847a016d0fbd31ffe1001b63355ed309651851295315031ea7eb5a9b"},
+    {file = "coverage-7.6.9-cp313-cp313t-win_amd64.whl", hash = "sha256:97ddc94d46088304772d21b060041c97fc16bdda13c6c7f9d8fcd8d5ae0d8611"},
+    {file = "coverage-7.6.9-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:adb697c0bd35100dc690de83154627fbab1f4f3c0386df266dded865fc50a902"},
+    {file = "coverage-7.6.9-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:be57b6d56e49c2739cdf776839a92330e933dd5e5d929966fbbd380c77f060be"},
+    {file = "coverage-7.6.9-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f1592791f8204ae9166de22ba7e6705fa4ebd02936c09436a1bb85aabca3e599"},
+    {file = "coverage-7.6.9-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e12ae8cc979cf83d258acb5e1f1cf2f3f83524d1564a49d20b8bec14b637f08"},
+    {file = "coverage-7.6.9-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb5555cff66c4d3d6213a296b360f9e1a8e323e74e0426b6c10ed7f4d021e464"},
+    {file = "coverage-7.6.9-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:b9389a429e0e5142e69d5bf4a435dd688c14478a19bb901735cdf75e57b13845"},
+    {file = "coverage-7.6.9-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:592ac539812e9b46046620341498caf09ca21023c41c893e1eb9dbda00a70cbf"},
+    {file = "coverage-7.6.9-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a27801adef24cc30871da98a105f77995e13a25a505a0161911f6aafbd66e678"},
+    {file = "coverage-7.6.9-cp39-cp39-win32.whl", hash = "sha256:8e3c3e38930cfb729cb8137d7f055e5a473ddaf1217966aa6238c88bd9fd50e6"},
+    {file = "coverage-7.6.9-cp39-cp39-win_amd64.whl", hash = "sha256:e28bf44afa2b187cc9f41749138a64435bf340adfcacb5b2290c070ce99839d4"},
+    {file = "coverage-7.6.9-pp39.pp310-none-any.whl", hash = "sha256:f3ca78518bc6bc92828cd11867b121891d75cae4ea9e908d72030609b996db1b"},
+    {file = "coverage-7.6.9.tar.gz", hash = "sha256:4a8d8977b0c6ef5aeadcb644da9e69ae0dcfe66ec7f368c89c72e058bd71164d"},
+]
+
+[package.dependencies]
+tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
+
+[package.extras]
+toml = ["tomli"]
 
 [[package]]
 name = "cryptography"
@@ -583,6 +679,18 @@ gevent = ["gevent (>=1.4.0)"]
 zookeeper = ["kazoo (>=2.0)"]
 
 [[package]]
+name = "distlib"
+version = "0.3.9"
+description = "Distribution utilities"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87"},
+    {file = "distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403"},
+]
+
+[[package]]
 name = "elasticsearch"
 version = "7.13.4"
 description = "Python client for Elasticsearch"
@@ -640,6 +748,23 @@ typing-extensions = ">=4.8.0"
 
 [package.extras]
 all = ["email-validator (>=2.0.0)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=2.11.2)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.5)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
+
+[[package]]
+name = "filelock"
+version = "3.16.1"
+description = "A platform independent file lock."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0"},
+    {file = "filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435"},
+]
+
+[package.extras]
+docs = ["furo (>=2024.8.6)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4.1)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.6.1)", "diff-cover (>=9.2)", "pytest (>=8.3.3)", "pytest-asyncio (>=0.24)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "pytest-timeout (>=2.3.1)", "virtualenv (>=20.26.4)"]
+typing = ["typing-extensions (>=4.12.2)"]
 
 [[package]]
 name = "frozenlist"
@@ -745,30 +870,31 @@ files = [
 
 [[package]]
 name = "h11"
-version = "0.14.0"
+version = "0.12.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.6"
 groups = ["main"]
 files = [
-    {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
-    {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
+    {file = "h11-0.12.0-py3-none-any.whl", hash = "sha256:36a3cb8c0a032f56e2da7084577878a035d3b61d104230d4bd49c0c6b555a9c6"},
+    {file = "h11-0.12.0.tar.gz", hash = "sha256:47222cb6067e4a307d535814917cd98fd0a57b6788ce715755fa2b6c28b56042"},
 ]
 
 [[package]]
 name = "httpcore"
-version = "0.13.2"
+version = "0.13.7"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
 files = [
-    {file = "httpcore-0.13.2-py3-none-any.whl", hash = "sha256:52b7d9413f6f5592a667de9209d70d4d41aba3fb0540dd7c93475c78b85941e9"},
-    {file = "httpcore-0.13.2.tar.gz", hash = "sha256:c16efbdf643e1b57bde0adc12c53b08645d7d92d6d345a3f71adfc2a083e7fd2"},
+    {file = "httpcore-0.13.7-py3-none-any.whl", hash = "sha256:369aa481b014cf046f7067fddd67d00560f2f00426e79569d99cb11245134af0"},
+    {file = "httpcore-0.13.7.tar.gz", hash = "sha256:036f960468759e633574d7c121afba48af6419615d36ab8ede979f1ad6276fa3"},
 ]
 
 [package.dependencies]
-h11 = "==0.*"
+anyio = "==3.*"
+h11 = ">=0.11,<0.13"
 sniffio = "==1.*"
 
 [package.extras]
@@ -804,19 +930,19 @@ test = ["Cython (==0.29.22)"]
 
 [[package]]
 name = "httpx"
-version = "0.18.1"
+version = "0.18.2"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
 files = [
-    {file = "httpx-0.18.1-py3-none-any.whl", hash = "sha256:ad2e3db847be736edc4b272c4d5788790a7e5789ef132fc6b5fef8aeb9e9f6e0"},
-    {file = "httpx-0.18.1.tar.gz", hash = "sha256:0a2651dd2b9d7662c70d12ada5c290abcf57373b9633515fe4baa9f62566086f"},
+    {file = "httpx-0.18.2-py3-none-any.whl", hash = "sha256:979afafecb7d22a1d10340bafb403cf2cb75aff214426ff206521fc79d26408c"},
+    {file = "httpx-0.18.2.tar.gz", hash = "sha256:9f99c15d33642d38bce8405df088c1c4cfd940284b4290cacbfb02e64f4877c6"},
 ]
 
 [package.dependencies]
 certifi = "*"
-httpcore = ">=0.13.0,<0.14.0"
+httpcore = ">=0.13.3,<0.14.0"
 rfc3986 = {version = ">=1.3,<2", extras = ["idna2008"]}
 sniffio = "*"
 
@@ -838,6 +964,18 @@ files = [
 
 [package.extras]
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
 
 [[package]]
 name = "jmespath"
@@ -1037,87 +1175,87 @@ signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
 name = "orjson"
-version = "3.10.14"
+version = "3.10.12"
 description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "orjson-3.10.14-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:849ea7845a55f09965826e816cdc7689d6cf74fe9223d79d758c714af955bcb6"},
-    {file = "orjson-3.10.14-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5947b139dfa33f72eecc63f17e45230a97e741942955a6c9e650069305eb73d"},
-    {file = "orjson-3.10.14-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cde6d76910d3179dae70f164466692f4ea36da124d6fb1a61399ca589e81d69a"},
-    {file = "orjson-3.10.14-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c6dfbaeb7afa77ca608a50e2770a0461177b63a99520d4928e27591b142c74b1"},
-    {file = "orjson-3.10.14-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fa45e489ef80f28ff0e5ba0a72812b8cfc7c1ef8b46a694723807d1b07c89ebb"},
-    {file = "orjson-3.10.14-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f5007abfdbb1d866e2aa8990bd1c465f0f6da71d19e695fc278282be12cffa5"},
-    {file = "orjson-3.10.14-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1b49e2af011c84c3f2d541bb5cd1e3c7c2df672223e7e3ea608f09cf295e5f8a"},
-    {file = "orjson-3.10.14-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:164ac155109226b3a2606ee6dda899ccfbe6e7e18b5bdc3fbc00f79cc074157d"},
-    {file = "orjson-3.10.14-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:6b1225024cf0ef5d15934b5ffe9baf860fe8bc68a796513f5ea4f5056de30bca"},
-    {file = "orjson-3.10.14-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:d6546e8073dc382e60fcae4a001a5a1bc46da5eab4a4878acc2d12072d6166d5"},
-    {file = "orjson-3.10.14-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9f1d2942605c894162252d6259b0121bf1cb493071a1ea8cb35d79cb3e6ac5bc"},
-    {file = "orjson-3.10.14-cp310-cp310-win32.whl", hash = "sha256:397083806abd51cf2b3bbbf6c347575374d160331a2d33c5823e22249ad3118b"},
-    {file = "orjson-3.10.14-cp310-cp310-win_amd64.whl", hash = "sha256:fa18f949d3183a8d468367056be989666ac2bef3a72eece0bade9cdb733b3c28"},
-    {file = "orjson-3.10.14-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:f506fd666dd1ecd15a832bebc66c4df45c1902fd47526292836c339f7ba665a9"},
-    {file = "orjson-3.10.14-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:efe5fd254cfb0eeee13b8ef7ecb20f5d5a56ddda8a587f3852ab2cedfefdb5f6"},
-    {file = "orjson-3.10.14-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4ddc8c866d7467f5ee2991397d2ea94bcf60d0048bdd8ca555740b56f9042725"},
-    {file = "orjson-3.10.14-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3af8e42ae4363773658b8d578d56dedffb4f05ceeb4d1d4dd3fb504950b45526"},
-    {file = "orjson-3.10.14-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:84dd83110503bc10e94322bf3ffab8bc49150176b49b4984dc1cce4c0a993bf9"},
-    {file = "orjson-3.10.14-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:36f5bfc0399cd4811bf10ec7a759c7ab0cd18080956af8ee138097d5b5296a95"},
-    {file = "orjson-3.10.14-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:868943660fb2a1e6b6b965b74430c16a79320b665b28dd4511d15ad5038d37d5"},
-    {file = "orjson-3.10.14-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:33449c67195969b1a677533dee9d76e006001213a24501333624623e13c7cc8e"},
-    {file = "orjson-3.10.14-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e4c9f60f9fb0b5be66e416dcd8c9d94c3eabff3801d875bdb1f8ffc12cf86905"},
-    {file = "orjson-3.10.14-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0de4d6315cfdbd9ec803b945c23b3a68207fd47cbe43626036d97e8e9561a436"},
-    {file = "orjson-3.10.14-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:83adda3db595cb1a7e2237029b3249c85afbe5c747d26b41b802e7482cb3933e"},
-    {file = "orjson-3.10.14-cp311-cp311-win32.whl", hash = "sha256:998019ef74a4997a9d741b1473533cdb8faa31373afc9849b35129b4b8ec048d"},
-    {file = "orjson-3.10.14-cp311-cp311-win_amd64.whl", hash = "sha256:9d034abdd36f0f0f2240f91492684e5043d46f290525d1117712d5b8137784eb"},
-    {file = "orjson-3.10.14-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:2ad4b7e367efba6dc3f119c9a0fcd41908b7ec0399a696f3cdea7ec477441b09"},
-    {file = "orjson-3.10.14-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f496286fc85e93ce0f71cc84fc1c42de2decf1bf494094e188e27a53694777a7"},
-    {file = "orjson-3.10.14-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7f189bbfcded40e41a6969c1068ba305850ba016665be71a217918931416fbf"},
-    {file = "orjson-3.10.14-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8cc8204f0b75606869c707da331058ddf085de29558b516fc43c73ee5ee2aadb"},
-    {file = "orjson-3.10.14-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:deaa2899dff7f03ab667e2ec25842d233e2a6a9e333efa484dfe666403f3501c"},
-    {file = "orjson-3.10.14-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1c3ea52642c9714dc6e56de8a451a066f6d2707d273e07fe8a9cc1ba073813d"},
-    {file = "orjson-3.10.14-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9d3f9ed72e7458ded9a1fb1b4d4ed4c4fdbaf82030ce3f9274b4dc1bff7ace2b"},
-    {file = "orjson-3.10.14-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:07520685d408a2aba514c17ccc16199ff2934f9f9e28501e676c557f454a37fe"},
-    {file = "orjson-3.10.14-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:76344269b550ea01488d19a2a369ab572c1ac4449a72e9f6ac0d70eb1cbfb953"},
-    {file = "orjson-3.10.14-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e2979d0f2959990620f7e62da6cd954e4620ee815539bc57a8ae46e2dacf90e3"},
-    {file = "orjson-3.10.14-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03f61ca3674555adcb1aa717b9fc87ae936aa7a63f6aba90a474a88701278780"},
-    {file = "orjson-3.10.14-cp312-cp312-win32.whl", hash = "sha256:d5075c54edf1d6ad81d4c6523ce54a748ba1208b542e54b97d8a882ecd810fd1"},
-    {file = "orjson-3.10.14-cp312-cp312-win_amd64.whl", hash = "sha256:175cafd322e458603e8ce73510a068d16b6e6f389c13f69bf16de0e843d7d406"},
-    {file = "orjson-3.10.14-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:0905ca08a10f7e0e0c97d11359609300eb1437490a7f32bbaa349de757e2e0c7"},
-    {file = "orjson-3.10.14-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:92d13292249f9f2a3e418cbc307a9fbbef043c65f4bd8ba1eb620bc2aaba3d15"},
-    {file = "orjson-3.10.14-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90937664e776ad316d64251e2fa2ad69265e4443067668e4727074fe39676414"},
-    {file = "orjson-3.10.14-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9ed3d26c4cb4f6babaf791aa46a029265850e80ec2a566581f5c2ee1a14df4f1"},
-    {file = "orjson-3.10.14-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:56ee546c2bbe9599aba78169f99d1dc33301853e897dbaf642d654248280dc6e"},
-    {file = "orjson-3.10.14-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:901e826cb2f1bdc1fcef3ef59adf0c451e8f7c0b5deb26c1a933fb66fb505eae"},
-    {file = "orjson-3.10.14-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26336c0d4b2d44636e1e1e6ed1002f03c6aae4a8a9329561c8883f135e9ff010"},
-    {file = "orjson-3.10.14-cp313-cp313-win32.whl", hash = "sha256:e2bc525e335a8545c4e48f84dd0328bc46158c9aaeb8a1c2276546e94540ea3d"},
-    {file = "orjson-3.10.14-cp313-cp313-win_amd64.whl", hash = "sha256:eca04dfd792cedad53dc9a917da1a522486255360cb4e77619343a20d9f35364"},
-    {file = "orjson-3.10.14-cp38-cp38-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9a0fba3b8a587a54c18585f077dcab6dd251c170d85cfa4d063d5746cd595a0f"},
-    {file = "orjson-3.10.14-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:175abf3d20e737fec47261d278f95031736a49d7832a09ab684026528c4d96db"},
-    {file = "orjson-3.10.14-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29ca1a93e035d570e8b791b6c0feddd403c6a5388bfe870bf2aa6bba1b9d9b8e"},
-    {file = "orjson-3.10.14-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f77202c80e8ab5a1d1e9faf642343bee5aaf332061e1ada4e9147dbd9eb00c46"},
-    {file = "orjson-3.10.14-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6e2ec73b7099b6a29b40a62e08a23b936423bd35529f8f55c42e27acccde7954"},
-    {file = "orjson-3.10.14-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2d1679df9f9cd9504f8dff24555c1eaabba8aad7f5914f28dab99e3c2552c9d"},
-    {file = "orjson-3.10.14-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:691ab9a13834310a263664313e4f747ceb93662d14a8bdf20eb97d27ed488f16"},
-    {file = "orjson-3.10.14-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:b11ed82054fce82fb74cea33247d825d05ad6a4015ecfc02af5fbce442fbf361"},
-    {file = "orjson-3.10.14-cp38-cp38-musllinux_1_2_armv7l.whl", hash = "sha256:e70a1d62b8288677d48f3bea66c21586a5f999c64ecd3878edb7393e8d1b548d"},
-    {file = "orjson-3.10.14-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:16642f10c1ca5611251bd835de9914a4b03095e28a34c8ba6a5500b5074338bd"},
-    {file = "orjson-3.10.14-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:3871bad546aa66c155e3f36f99c459780c2a392d502a64e23fb96d9abf338511"},
-    {file = "orjson-3.10.14-cp38-cp38-win32.whl", hash = "sha256:0293a88815e9bb5c90af4045f81ed364d982f955d12052d989d844d6c4e50945"},
-    {file = "orjson-3.10.14-cp38-cp38-win_amd64.whl", hash = "sha256:6169d3868b190d6b21adc8e61f64e3db30f50559dfbdef34a1cd6c738d409dfc"},
-    {file = "orjson-3.10.14-cp39-cp39-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:06d4ec218b1ec1467d8d64da4e123b4794c781b536203c309ca0f52819a16c03"},
-    {file = "orjson-3.10.14-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:962c2ec0dcaf22b76dee9831fdf0c4a33d4bf9a257a2bc5d4adc00d5c8ad9034"},
-    {file = "orjson-3.10.14-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:21d3be4132f71ef1360385770474f29ea1538a242eef72ac4934fe142800e37f"},
-    {file = "orjson-3.10.14-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c28ed60597c149a9e3f5ad6dd9cebaee6fb2f0e3f2d159a4a2b9b862d4748860"},
-    {file = "orjson-3.10.14-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7e947f70167fe18469f2023644e91ab3d24f9aed69a5e1c78e2c81b9cea553fb"},
-    {file = "orjson-3.10.14-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64410696c97a35af2432dea7bdc4ce32416458159430ef1b4beb79fd30093ad6"},
-    {file = "orjson-3.10.14-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8050a5d81c022561ee29cd2739de5b4445f3c72f39423fde80a63299c1892c52"},
-    {file = "orjson-3.10.14-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:b49a28e30d3eca86db3fe6f9b7f4152fcacbb4a467953cd1b42b94b479b77956"},
-    {file = "orjson-3.10.14-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:ca041ad20291a65d853a9523744eebc3f5a4b2f7634e99f8fe88320695ddf766"},
-    {file = "orjson-3.10.14-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:d313a2998b74bb26e9e371851a173a9b9474764916f1fc7971095699b3c6e964"},
-    {file = "orjson-3.10.14-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:7796692136a67b3e301ef9052bde6fe8e7bd5200da766811a3a608ffa62aaff0"},
-    {file = "orjson-3.10.14-cp39-cp39-win32.whl", hash = "sha256:eee4bc767f348fba485ed9dc576ca58b0a9eac237f0e160f7a59bce628ed06b3"},
-    {file = "orjson-3.10.14-cp39-cp39-win_amd64.whl", hash = "sha256:96a1c0ee30fb113b3ae3c748fd75ca74a157ff4c58476c47db4d61518962a011"},
-    {file = "orjson-3.10.14.tar.gz", hash = "sha256:cf31f6f071a6b8e7aa1ead1fa27b935b48d00fbfa6a28ce856cfff2d5dd68eed"},
+    {file = "orjson-3.10.12-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:ece01a7ec71d9940cc654c482907a6b65df27251255097629d0dea781f255c6d"},
+    {file = "orjson-3.10.12-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c34ec9aebc04f11f4b978dd6caf697a2df2dd9b47d35aa4cc606cabcb9df69d7"},
+    {file = "orjson-3.10.12-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fd6ec8658da3480939c79b9e9e27e0db31dffcd4ba69c334e98c9976ac29140e"},
+    {file = "orjson-3.10.12-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f17e6baf4cf01534c9de8a16c0c611f3d94925d1701bf5f4aff17003677d8ced"},
+    {file = "orjson-3.10.12-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6402ebb74a14ef96f94a868569f5dccf70d791de49feb73180eb3c6fda2ade56"},
+    {file = "orjson-3.10.12-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0000758ae7c7853e0a4a6063f534c61656ebff644391e1f81698c1b2d2fc8cd2"},
+    {file = "orjson-3.10.12-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:888442dcee99fd1e5bd37a4abb94930915ca6af4db50e23e746cdf4d1e63db13"},
+    {file = "orjson-3.10.12-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c1f7a3ce79246aa0e92f5458d86c54f257fb5dfdc14a192651ba7ec2c00f8a05"},
+    {file = "orjson-3.10.12-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:802a3935f45605c66fb4a586488a38af63cb37aaad1c1d94c982c40dcc452e85"},
+    {file = "orjson-3.10.12-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:1da1ef0113a2be19bb6c557fb0ec2d79c92ebd2fed4cfb1b26bab93f021fb885"},
+    {file = "orjson-3.10.12-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7a3273e99f367f137d5b3fecb5e9f45bcdbfac2a8b2f32fbc72129bbd48789c2"},
+    {file = "orjson-3.10.12-cp310-none-win32.whl", hash = "sha256:475661bf249fd7907d9b0a2a2421b4e684355a77ceef85b8352439a9163418c3"},
+    {file = "orjson-3.10.12-cp310-none-win_amd64.whl", hash = "sha256:87251dc1fb2b9e5ab91ce65d8f4caf21910d99ba8fb24b49fd0c118b2362d509"},
+    {file = "orjson-3.10.12-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:a734c62efa42e7df94926d70fe7d37621c783dea9f707a98cdea796964d4cf74"},
+    {file = "orjson-3.10.12-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:750f8b27259d3409eda8350c2919a58b0cfcd2054ddc1bd317a643afc646ef23"},
+    {file = "orjson-3.10.12-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bb52c22bfffe2857e7aa13b4622afd0dd9d16ea7cc65fd2bf318d3223b1b6252"},
+    {file = "orjson-3.10.12-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:440d9a337ac8c199ff8251e100c62e9488924c92852362cd27af0e67308c16ef"},
+    {file = "orjson-3.10.12-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a9e15c06491c69997dfa067369baab3bf094ecb74be9912bdc4339972323f252"},
+    {file = "orjson-3.10.12-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:362d204ad4b0b8724cf370d0cd917bb2dc913c394030da748a3bb632445ce7c4"},
+    {file = "orjson-3.10.12-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2b57cbb4031153db37b41622eac67329c7810e5f480fda4cfd30542186f006ae"},
+    {file = "orjson-3.10.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:165c89b53ef03ce0d7c59ca5c82fa65fe13ddf52eeb22e859e58c237d4e33b9b"},
+    {file = "orjson-3.10.12-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:5dee91b8dfd54557c1a1596eb90bcd47dbcd26b0baaed919e6861f076583e9da"},
+    {file = "orjson-3.10.12-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:77a4e1cfb72de6f905bdff061172adfb3caf7a4578ebf481d8f0530879476c07"},
+    {file = "orjson-3.10.12-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:038d42c7bc0606443459b8fe2d1f121db474c49067d8d14c6a075bbea8bf14dd"},
+    {file = "orjson-3.10.12-cp311-none-win32.whl", hash = "sha256:03b553c02ab39bed249bedd4abe37b2118324d1674e639b33fab3d1dafdf4d79"},
+    {file = "orjson-3.10.12-cp311-none-win_amd64.whl", hash = "sha256:8b8713b9e46a45b2af6b96f559bfb13b1e02006f4242c156cbadef27800a55a8"},
+    {file = "orjson-3.10.12-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:53206d72eb656ca5ac7d3a7141e83c5bbd3ac30d5eccfe019409177a57634b0d"},
+    {file = "orjson-3.10.12-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac8010afc2150d417ebda810e8df08dd3f544e0dd2acab5370cfa6bcc0662f8f"},
+    {file = "orjson-3.10.12-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed459b46012ae950dd2e17150e838ab08215421487371fa79d0eced8d1461d70"},
+    {file = "orjson-3.10.12-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8dcb9673f108a93c1b52bfc51b0af422c2d08d4fc710ce9c839faad25020bb69"},
+    {file = "orjson-3.10.12-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:22a51ae77680c5c4652ebc63a83d5255ac7d65582891d9424b566fb3b5375ee9"},
+    {file = "orjson-3.10.12-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:910fdf2ac0637b9a77d1aad65f803bac414f0b06f720073438a7bd8906298192"},
+    {file = "orjson-3.10.12-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:24ce85f7100160936bc2116c09d1a8492639418633119a2224114f67f63a4559"},
+    {file = "orjson-3.10.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a76ba5fc8dd9c913640292df27bff80a685bed3a3c990d59aa6ce24c352f8fc"},
+    {file = "orjson-3.10.12-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:ff70ef093895fd53f4055ca75f93f047e088d1430888ca1229393a7c0521100f"},
+    {file = "orjson-3.10.12-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:f4244b7018b5753ecd10a6d324ec1f347da130c953a9c88432c7fbc8875d13be"},
+    {file = "orjson-3.10.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:16135ccca03445f37921fa4b585cff9a58aa8d81ebcb27622e69bfadd220b32c"},
+    {file = "orjson-3.10.12-cp312-none-win32.whl", hash = "sha256:2d879c81172d583e34153d524fcba5d4adafbab8349a7b9f16ae511c2cee8708"},
+    {file = "orjson-3.10.12-cp312-none-win_amd64.whl", hash = "sha256:fc23f691fa0f5c140576b8c365bc942d577d861a9ee1142e4db468e4e17094fb"},
+    {file = "orjson-3.10.12-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:47962841b2a8aa9a258b377f5188db31ba49af47d4003a32f55d6f8b19006543"},
+    {file = "orjson-3.10.12-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6334730e2532e77b6054e87ca84f3072bee308a45a452ea0bffbbbc40a67e296"},
+    {file = "orjson-3.10.12-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:accfe93f42713c899fdac2747e8d0d5c659592df2792888c6c5f829472e4f85e"},
+    {file = "orjson-3.10.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a7974c490c014c48810d1dede6c754c3cc46598da758c25ca3b4001ac45b703f"},
+    {file = "orjson-3.10.12-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:3f250ce7727b0b2682f834a3facff88e310f52f07a5dcfd852d99637d386e79e"},
+    {file = "orjson-3.10.12-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f31422ff9486ae484f10ffc51b5ab2a60359e92d0716fcce1b3593d7bb8a9af6"},
+    {file = "orjson-3.10.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5f29c5d282bb2d577c2a6bbde88d8fdcc4919c593f806aac50133f01b733846e"},
+    {file = "orjson-3.10.12-cp313-none-win32.whl", hash = "sha256:f45653775f38f63dc0e6cd4f14323984c3149c05d6007b58cb154dd080ddc0dc"},
+    {file = "orjson-3.10.12-cp313-none-win_amd64.whl", hash = "sha256:229994d0c376d5bdc91d92b3c9e6be2f1fbabd4cc1b59daae1443a46ee5e9825"},
+    {file = "orjson-3.10.12-cp38-cp38-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:7d69af5b54617a5fac5c8e5ed0859eb798e2ce8913262eb522590239db6c6763"},
+    {file = "orjson-3.10.12-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ed119ea7d2953365724a7059231a44830eb6bbb0cfead33fcbc562f5fd8f935"},
+    {file = "orjson-3.10.12-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9c5fc1238ef197e7cad5c91415f524aaa51e004be5a9b35a1b8a84ade196f73f"},
+    {file = "orjson-3.10.12-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:43509843990439b05f848539d6f6198d4ac86ff01dd024b2f9a795c0daeeab60"},
+    {file = "orjson-3.10.12-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f72e27a62041cfb37a3de512247ece9f240a561e6c8662276beaf4d53d406db4"},
+    {file = "orjson-3.10.12-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a904f9572092bb6742ab7c16c623f0cdccbad9eeb2d14d4aa06284867bddd31"},
+    {file = "orjson-3.10.12-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:855c0833999ed5dc62f64552db26f9be767434917d8348d77bacaab84f787d7b"},
+    {file = "orjson-3.10.12-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:897830244e2320f6184699f598df7fb9db9f5087d6f3f03666ae89d607e4f8ed"},
+    {file = "orjson-3.10.12-cp38-cp38-musllinux_1_2_armv7l.whl", hash = "sha256:0b32652eaa4a7539f6f04abc6243619c56f8530c53bf9b023e1269df5f7816dd"},
+    {file = "orjson-3.10.12-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:36b4aa31e0f6a1aeeb6f8377769ca5d125db000f05c20e54163aef1d3fe8e833"},
+    {file = "orjson-3.10.12-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:5535163054d6cbf2796f93e4f0dbc800f61914c0e3c4ed8499cf6ece22b4a3da"},
+    {file = "orjson-3.10.12-cp38-none-win32.whl", hash = "sha256:90a5551f6f5a5fa07010bf3d0b4ca2de21adafbbc0af6cb700b63cd767266cb9"},
+    {file = "orjson-3.10.12-cp38-none-win_amd64.whl", hash = "sha256:703a2fb35a06cdd45adf5d733cf613cbc0cb3ae57643472b16bc22d325b5fb6c"},
+    {file = "orjson-3.10.12-cp39-cp39-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:f29de3ef71a42a5822765def1febfb36e0859d33abf5c2ad240acad5c6a1b78d"},
+    {file = "orjson-3.10.12-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:de365a42acc65d74953f05e4772c974dad6c51cfc13c3240899f534d611be967"},
+    {file = "orjson-3.10.12-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:91a5a0158648a67ff0004cb0df5df7dcc55bfc9ca154d9c01597a23ad54c8d0c"},
+    {file = "orjson-3.10.12-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c47ce6b8d90fe9646a25b6fb52284a14ff215c9595914af63a5933a49972ce36"},
+    {file = "orjson-3.10.12-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0eee4c2c5bfb5c1b47a5db80d2ac7aaa7e938956ae88089f098aff2c0f35d5d8"},
+    {file = "orjson-3.10.12-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:35d3081bbe8b86587eb5c98a73b97f13d8f9fea685cf91a579beddacc0d10566"},
+    {file = "orjson-3.10.12-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c23a6e90383884068bc2dba83d5222c9fcc3b99a0ed2411d38150734236755"},
+    {file = "orjson-3.10.12-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:5472be7dc3269b4b52acba1433dac239215366f89dc1d8d0e64029abac4e714e"},
+    {file = "orjson-3.10.12-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:7319cda750fca96ae5973efb31b17d97a5c5225ae0bc79bf5bf84df9e1ec2ab6"},
+    {file = "orjson-3.10.12-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:74d5ca5a255bf20b8def6a2b96b1e18ad37b4a122d59b154c458ee9494377f80"},
+    {file = "orjson-3.10.12-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:ff31d22ecc5fb85ef62c7d4afe8301d10c558d00dd24274d4bbe464380d3cd69"},
+    {file = "orjson-3.10.12-cp39-none-win32.whl", hash = "sha256:c22c3ea6fba91d84fcb4cda30e64aff548fcf0c44c876e681f47d61d24b12e6b"},
+    {file = "orjson-3.10.12-cp39-none-win_amd64.whl", hash = "sha256:be604f60d45ace6b0b33dd990a66b4526f1a7a186ac411c942674625456ca548"},
+    {file = "orjson-3.10.12.tar.gz", hash = "sha256:0a78bbda3aea0f9f079057ee1ee8a1ecf790d4f1af88dd67493c6b8ee52506ff"},
 ]
 
 [[package]]
@@ -1180,6 +1318,39 @@ pytz = ">=2017.3"
 
 [package.extras]
 test = ["hypothesis (>=3.58)", "pytest (>=5.0.1)", "pytest-xdist"]
+
+[[package]]
+name = "platformdirs"
+version = "4.3.6"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
+    {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
+]
+
+[package.extras]
+docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)"]
+type = ["mypy (>=1.11.2)"]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
+    {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "propcache"
@@ -1423,6 +1594,87 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
+
+[[package]]
+name = "pyproject-api"
+version = "1.8.0"
+description = "API to interact with the python pyproject.toml based projects"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pyproject_api-1.8.0-py3-none-any.whl", hash = "sha256:3d7d347a047afe796fd5d1885b1e391ba29be7169bd2f102fcd378f04273d228"},
+    {file = "pyproject_api-1.8.0.tar.gz", hash = "sha256:77b8049f2feb5d33eefcc21b57f1e279636277a8ac8ad6b5871037b243778496"},
+]
+
+[package.dependencies]
+packaging = ">=24.1"
+tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+docs = ["furo (>=2024.8.6)", "sphinx-autodoc-typehints (>=2.4.1)"]
+testing = ["covdefaults (>=2.3)", "pytest (>=8.3.3)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "setuptools (>=75.1)"]
+
+[[package]]
+name = "pytest"
+version = "8.3.4"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6"},
+    {file = "pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=1.5,<2"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.24.0"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pytest_asyncio-0.24.0-py3-none-any.whl", hash = "sha256:a811296ed596b69bf0b6f3dc40f83bcaf341b155a269052d82efa2b25ac7037b"},
+    {file = "pytest_asyncio-0.24.0.tar.gz", hash = "sha256:d081d828e576d85f875399194281e92bf8a68d60d72d1a2faf2feddb6c46b276"},
+]
+
+[package.dependencies]
+pytest = ">=8.2,<9"
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
+
+[[package]]
+name = "pytest-cov"
+version = "6.0.0"
+description = "Pytest plugin for measuring coverage."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0"},
+    {file = "pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35"},
+]
+
+[package.dependencies]
+coverage = {version = ">=7.5", extras = ["toml"]}
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
 name = "python-dateutil"
@@ -1715,6 +1967,77 @@ files = [
 ]
 
 [[package]]
+name = "tomli"
+version = "2.2.1"
+description = "A lil' TOML parser"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "python_full_version <= \"3.11.0a6\""
+files = [
+    {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
+    {file = "tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6"},
+    {file = "tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a"},
+    {file = "tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee"},
+    {file = "tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e"},
+    {file = "tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4"},
+    {file = "tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106"},
+    {file = "tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8"},
+    {file = "tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff"},
+    {file = "tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b"},
+    {file = "tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea"},
+    {file = "tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8"},
+    {file = "tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192"},
+    {file = "tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222"},
+    {file = "tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77"},
+    {file = "tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6"},
+    {file = "tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd"},
+    {file = "tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e"},
+    {file = "tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98"},
+    {file = "tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4"},
+    {file = "tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7"},
+    {file = "tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c"},
+    {file = "tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13"},
+    {file = "tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281"},
+    {file = "tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272"},
+    {file = "tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140"},
+    {file = "tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2"},
+    {file = "tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744"},
+    {file = "tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec"},
+    {file = "tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69"},
+    {file = "tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc"},
+    {file = "tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff"},
+]
+
+[[package]]
+name = "tox"
+version = "4.23.2"
+description = "tox is a generic virtualenv management and test command line tool"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "tox-4.23.2-py3-none-any.whl", hash = "sha256:452bc32bb031f2282881a2118923176445bac783ab97c874b8770ab4c3b76c38"},
+    {file = "tox-4.23.2.tar.gz", hash = "sha256:86075e00e555df6e82e74cfc333917f91ecb47ffbc868dcafbd2672e332f4a2c"},
+]
+
+[package.dependencies]
+cachetools = ">=5.5"
+chardet = ">=5.2"
+colorama = ">=0.4.6"
+filelock = ">=3.16.1"
+packaging = ">=24.1"
+platformdirs = ">=4.3.6"
+pluggy = ">=1.5"
+pyproject-api = ">=1.8"
+tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
+typing-extensions = {version = ">=4.12.2", markers = "python_version < \"3.11\""}
+virtualenv = ">=20.26.6"
+
+[package.extras]
+test = ["devpi-process (>=1.0.2)", "pytest (>=8.3.3)", "pytest-mock (>=3.14)"]
+
+[[package]]
 name = "trio"
 version = "0.18.0"
 description = "A friendly Python library for async concurrency and I/O"
@@ -1766,23 +2089,23 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "uvicorn"
-version = "0.14.0"
+version = "0.32.1"
 description = "The lightning-fast ASGI server."
 optional = false
-python-versions = "*"
+python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "uvicorn-0.14.0-py3-none-any.whl", hash = "sha256:2a76bb359171a504b3d1c853409af3adbfa5cef374a4a59e5881945a97a93eae"},
-    {file = "uvicorn-0.14.0.tar.gz", hash = "sha256:45ad7dfaaa7d55cab4cd1e85e03f27e9d60bc067ddc59db52a2b0aeca8870292"},
+    {file = "uvicorn-0.32.1-py3-none-any.whl", hash = "sha256:82ad92fd58da0d12af7482ecdb5f2470a04c9c9a53ced65b9bbb4a205377602e"},
+    {file = "uvicorn-0.32.1.tar.gz", hash = "sha256:ee9519c246a72b1c084cea8d3b44ed6026e78a4a309cbedae9c37e4cb9fbb175"},
 ]
 
 [package.dependencies]
-asgiref = ">=3.3.4"
-click = ">=7"
+click = ">=7.0"
 h11 = ">=0.8"
+typing-extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
-standard = ["PyYAML (>=5.1)", "colorama (>=0.4)", "httptools (==0.2.*)", "python-dotenv (>=0.13)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "watchgod (>=0.6)", "websockets (>=9.1)"]
+standard = ["colorama (>=0.4)", "httptools (>=0.6.3)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "watchfiles (>=0.13)", "websockets (>=10.4)"]
 
 [[package]]
 name = "uvloop"
@@ -1808,6 +2131,27 @@ files = [
 dev = ["Cython (>=0.29.20,<0.30.0)", "Sphinx (>=1.7.3,<1.8.0)", "aiohttp", "flake8 (>=3.8.4,<3.9.0)", "mypy (>=0.800)", "psutil", "pyOpenSSL (>=19.0.0,<19.1.0)", "pycodestyle (>=2.6.0,<2.7.0)", "pytest (>=3.6.0)", "sphinx-rtd-theme (>=0.2.4,<0.3.0)", "sphinxcontrib-asyncio (>=0.2.0,<0.3.0)"]
 docs = ["Sphinx (>=1.7.3,<1.8.0)", "sphinx-rtd-theme (>=0.2.4,<0.3.0)", "sphinxcontrib-asyncio (>=0.2.0,<0.3.0)"]
 test = ["aiohttp", "flake8 (>=3.8.4,<3.9.0)", "mypy (>=0.800)", "psutil", "pyOpenSSL (>=19.0.0,<19.1.0)", "pycodestyle (>=2.6.0,<2.7.0)"]
+
+[[package]]
+name = "virtualenv"
+version = "20.28.0"
+description = "Virtual Python Environment builder"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "virtualenv-20.28.0-py3-none-any.whl", hash = "sha256:23eae1b4516ecd610481eda647f3a7c09aea295055337331bb4e6892ecce47b0"},
+    {file = "virtualenv-20.28.0.tar.gz", hash = "sha256:2c9c3262bb8e7b87ea801d715fae4495e6032450c71d2309be9550e7364049aa"},
+]
+
+[package.dependencies]
+distlib = ">=0.3.7,<1"
+filelock = ">=3.12.2,<4"
+platformdirs = ">=3.9.1,<5"
+
+[package.extras]
+docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
+test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
 
 [[package]]
 name = "vyper-config"
@@ -1884,84 +2228,77 @@ files = [
 
 [[package]]
 name = "wrapt"
-version = "1.17.1"
+version = "1.17.0"
 description = "Module for decorators, wrappers and monkey patching."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "wrapt-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9176057c60438c2ce2284cdefc2b3ee5eddc8c87cd6e24c558d9f5c64298fa4a"},
-    {file = "wrapt-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e0f0e731e0ca1583befd3af71b9f90d64ded1535da7b80181cb9e907cc10bbae"},
-    {file = "wrapt-1.17.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:144ed42a4ec3aca5d6f1524f99ee49493bbd0d9c66c24da7ec44b4661dca4dcc"},
-    {file = "wrapt-1.17.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e8a7b0699a381226d81d75b48ea58414beb5891ba8982bdc8e42912f766de074"},
-    {file = "wrapt-1.17.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b20fcef5a3ee410671a5a59472e1ff9dda21cfbe5dfd15e23ee4b99ac455c8e"},
-    {file = "wrapt-1.17.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b9a58a1cbdc0588ed4c8ab0c191002d5d831a58c3bad88523fe471ea97eaf57d"},
-    {file = "wrapt-1.17.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:50bbfa7a92da7540426c774e09d6901e44d8f9b513b276ebae03ae244f0c6dbf"},
-    {file = "wrapt-1.17.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:09f5141599eaf36d6cc0b760ad87c2ab6b8618d009b2922639266676775a73a6"},
-    {file = "wrapt-1.17.1-cp310-cp310-win32.whl", hash = "sha256:589f24449fd58508533c4a69b2a0f45e9e3419b86b43a0607e2fdb989c6f2552"},
-    {file = "wrapt-1.17.1-cp310-cp310-win_amd64.whl", hash = "sha256:7eca3a1afa9820785b79cb137c68ca38c2f77cfedc3120115da42e1d5800907e"},
-    {file = "wrapt-1.17.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:da0d0c1c4bd55f9ace919454776dbf0821f537b9a77f739f0c3e34b14728b3b3"},
-    {file = "wrapt-1.17.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cd7649f0c493d35f9aad9790bbecd7b6fd2e2f7141f6cb1e1e9bb7a681d6d0a4"},
-    {file = "wrapt-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0aad4f54b3155d673a5c4706a71a0a84f3d415b2fc8a2a399a964d70f18846a2"},
-    {file = "wrapt-1.17.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ebea3ebb6a394f50f150a52e279508e91c8770625ac8fcb5d8cf35995a320f2"},
-    {file = "wrapt-1.17.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:53e2986a65eba7c399d7ad1ccd204562d4ffe6e937344fe5a49eb5a83858f797"},
-    {file = "wrapt-1.17.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67c30d3fe245adb0eb1061a0e526905970a0dabe7c5fba5078e0ee9d19f28167"},
-    {file = "wrapt-1.17.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:6fd88935b12b59a933ef45facb57575095f205d30d0ae8dd1a3b485bc4fa2fbd"},
-    {file = "wrapt-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec3e763e7ca8dcba0792fc3e8ff7061186f59e9aafe4438e6bb1f635a6ab0901"},
-    {file = "wrapt-1.17.1-cp311-cp311-win32.whl", hash = "sha256:d792631942a102d6d4f71e4948aceb307310ac0a0af054be6d28b4f79583e0f1"},
-    {file = "wrapt-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:3dfd4738a630eddfcb7ff6c8e9fe863df3821f9c991dec73821e05450074ae09"},
-    {file = "wrapt-1.17.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b1a4c8edd038fee0ce67bf119b16eaa45d22a52bbaf7d0a17d2312eb0003b1bb"},
-    {file = "wrapt-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:181a844005c9818792212a32e004cb4c6bd8e35cae8e97b1a39a1918d95cef58"},
-    {file = "wrapt-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21ffcf16f5c243a626b0f8da637948e3d5984e3bc0c1bc500ad990e88e974e3b"},
-    {file = "wrapt-1.17.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0eb33799b7582bb73787b9903b70595f8eff67eecc9455f668ed01adf53f9eea"},
-    {file = "wrapt-1.17.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:57e932ad1908b53e9ad67a746432f02bc8473a9ee16e26a47645a2b224fba5fd"},
-    {file = "wrapt-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b8bd35c15bc82c5cbe397e8196fa57a17ce5d3f30e925a6fd39e4c5bb02fdcff"},
-    {file = "wrapt-1.17.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:93018dbb956e0ad99ea2fa2c3c22f033549dcb1f56ad9f4555dfe25e49688c5d"},
-    {file = "wrapt-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5bd9186d52cf3d36bf1823be0e85297e4dbad909bc6dd495ce0d272806d84a7"},
-    {file = "wrapt-1.17.1-cp312-cp312-win32.whl", hash = "sha256:d609f0ab0603bbcbf2de906b366b9f9bec75c32b4493550a940de658cc2ce512"},
-    {file = "wrapt-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:2c160bb8815787646b27a0c8575a26a4d6bf6abd7c5eb250ad3f2d38b29cb2cb"},
-    {file = "wrapt-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:99e544e6ce26f89ad5acc6f407bc4daf7c1d42321e836f5c768f834100bdf35c"},
-    {file = "wrapt-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:78da796b74f2c8e0af021ee99feb3bff7cb46f8e658fe25c20e66be1080db4a2"},
-    {file = "wrapt-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f1bc359f6c52e53565e7af24b423e7a1eea97d155f38ac9e90e95303514710b"},
-    {file = "wrapt-1.17.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cbead724daa13cae46e8ab3bb24938d8514d123f34345535b184f3eb1b7ad717"},
-    {file = "wrapt-1.17.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdf7b0e3d3713331c0bb9daac47cd10e5aa60d060e53696f50de4e560bd5617f"},
-    {file = "wrapt-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f17e8d926f63aed65ff949682c922f96d00f65c2e852c24272232313fa7823d5"},
-    {file = "wrapt-1.17.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:9e04f3bd30e0b23c0ca7e1d4084e7d28b6d7d2feb8b7bc69b496fe881280579b"},
-    {file = "wrapt-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5660e470edfa15ae7ef407272c642d29e9962777a6b30bfa8fc0da2173dc9afd"},
-    {file = "wrapt-1.17.1-cp313-cp313-win32.whl", hash = "sha256:a992f9e019145e84616048556546edeaba68e05e1c1ffbe8391067a63cdadb0c"},
-    {file = "wrapt-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:5c2e24ba455af4b0a237a890ea6ed9bafd01fac2c47095f87c53ea3344215d43"},
-    {file = "wrapt-1.17.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:88623fd957ba500d8bb0f7427a76496d99313ca2f9e932481c0882e034cf1add"},
-    {file = "wrapt-1.17.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:162d5f15bdd3b8037e06540902227ef9e0f298496c0afaadd9e2875851446693"},
-    {file = "wrapt-1.17.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6bb82447ddae4e3d9b51f40c494f66e6cbd8fb0e8e8b993678416535c67f9a0d"},
-    {file = "wrapt-1.17.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ce4cff3922707048d754e365c4ebf41a3bcbf29b329349bf85d51873c7c7e9e"},
-    {file = "wrapt-1.17.1-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fdc4e73a3fa0c25eed4d836d9732226f0326957cb075044a7f252b465299433"},
-    {file = "wrapt-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:bca1c0824f824bcd97b4b179dd55dcad1dab419252be2b2faebbcacefa3b27b2"},
-    {file = "wrapt-1.17.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:6d44b14f3a2f6343a07c90344850b7af5515538ce3a5d01f9c87d8bae9bd8724"},
-    {file = "wrapt-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:169033329022739c6f0d8cd3031a113953b0ba500f3d5978904bdd40baec4568"},
-    {file = "wrapt-1.17.1-cp313-cp313t-win32.whl", hash = "sha256:52f0907287d9104112dbebda46af4db0793fcc4c64c8a867099212d116b6db64"},
-    {file = "wrapt-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:7966f98fa36933333d8a1c3d8552aa3d0735001901a4aabcfbd5a502b4ef14fe"},
-    {file = "wrapt-1.17.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:27a49f217839bf559d436308bae8fc4a9dd0ac98ffdb9d6aeb3f00385b0fb72c"},
-    {file = "wrapt-1.17.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:50a4e3b45e62b1ccb96b3fc0e427f1b458ff2e0def34ae084de88418157a09d1"},
-    {file = "wrapt-1.17.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30c0c08434fe2af6e40c5c75c036d7e3c7e7f499079fc479e740d9586b09fb0d"},
-    {file = "wrapt-1.17.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:15f96fe5e2efdc613983327240ae89cf6368c07eeb0f194d240e9549aa1ea739"},
-    {file = "wrapt-1.17.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14f78f8c313884f889c6696af62aa881af302a989a7c0df398d2b541fa53e8a9"},
-    {file = "wrapt-1.17.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:d87334b521ab0e2564902c0b10039dee8670485e9d397fe97c34b88801f474f7"},
-    {file = "wrapt-1.17.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:97eaff096fcb467e0f486f3bf354c1072245c2045859d71ba71158717ec97dcc"},
-    {file = "wrapt-1.17.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:13887d1415dc0e213a9adeb9026ae1f427023f77110d988fbd478643490aa40c"},
-    {file = "wrapt-1.17.1-cp38-cp38-win32.whl", hash = "sha256:823a262d967cbdf835787039b873ff551e36c14658bdc2e43267968b67f61f88"},
-    {file = "wrapt-1.17.1-cp38-cp38-win_amd64.whl", hash = "sha256:889587664d245dae75c752b643061f922e8a590d43a4cd088eca415ca83f2d13"},
-    {file = "wrapt-1.17.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:997e8f9b984e4263993d3baf3329367e7c7673b63789bc761718a6f9ed68653d"},
-    {file = "wrapt-1.17.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:bac64f57a5a7926ebc9ab519fb9eba1fc6dcd1f65d7f45937b2ce38da65c2270"},
-    {file = "wrapt-1.17.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a7aa07603d67007c15b33d20095cc9276f3e127bfb1b8106b3e84ec6907d137e"},
-    {file = "wrapt-1.17.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c53ef8936c4d587cb96bb1cf0d076e822fa38266c2b646837ef60465da8db22e"},
-    {file = "wrapt-1.17.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e72053cc4706dac537d5a772135dc3e1de5aff52883f49994c1757c1b2dc9db2"},
-    {file = "wrapt-1.17.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0ee037e4cc9d039efe712b13c483f4efa2c3499642369e01570b3bb1842eea3f"},
-    {file = "wrapt-1.17.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:20888d886186d19eab53816db2e615950b1ce7dbd5c239107daf2c8a6a4a03c6"},
-    {file = "wrapt-1.17.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:1c119802ae432b8c5d55dd5253825d09c1dca1c97ffc7b32c53ecdb348712f64"},
-    {file = "wrapt-1.17.1-cp39-cp39-win32.whl", hash = "sha256:3260178f3bc006acae93378bfd6dbf33c9249de93cc1b78d8cc7b7416f4ea99a"},
-    {file = "wrapt-1.17.1-cp39-cp39-win_amd64.whl", hash = "sha256:18fb16fb6bb75f4ec6272829007f3129a9a5264d0230372f9651e5f75cfec552"},
-    {file = "wrapt-1.17.1-py3-none-any.whl", hash = "sha256:f3117feb1fc479eaf84b549d3f229d5d2abdb823f003bc2a1c6dd70072912fa0"},
-    {file = "wrapt-1.17.1.tar.gz", hash = "sha256:16b2fdfa09a74a3930175b6d9d7d008022aa72a4f02de2b3eecafcc1adfd3cfe"},
+    {file = "wrapt-1.17.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a0c23b8319848426f305f9cb0c98a6e32ee68a36264f45948ccf8e7d2b941f8"},
+    {file = "wrapt-1.17.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b1ca5f060e205f72bec57faae5bd817a1560fcfc4af03f414b08fa29106b7e2d"},
+    {file = "wrapt-1.17.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e185ec6060e301a7e5f8461c86fb3640a7beb1a0f0208ffde7a65ec4074931df"},
+    {file = "wrapt-1.17.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb90765dd91aed05b53cd7a87bd7f5c188fcd95960914bae0d32c5e7f899719d"},
+    {file = "wrapt-1.17.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:879591c2b5ab0a7184258274c42a126b74a2c3d5a329df16d69f9cee07bba6ea"},
+    {file = "wrapt-1.17.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:fce6fee67c318fdfb7f285c29a82d84782ae2579c0e1b385b7f36c6e8074fffb"},
+    {file = "wrapt-1.17.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0698d3a86f68abc894d537887b9bbf84d29bcfbc759e23f4644be27acf6da301"},
+    {file = "wrapt-1.17.0-cp310-cp310-win32.whl", hash = "sha256:69d093792dc34a9c4c8a70e4973a3361c7a7578e9cd86961b2bbf38ca71e4e22"},
+    {file = "wrapt-1.17.0-cp310-cp310-win_amd64.whl", hash = "sha256:f28b29dc158ca5d6ac396c8e0a2ef45c4e97bb7e65522bfc04c989e6fe814575"},
+    {file = "wrapt-1.17.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:74bf625b1b4caaa7bad51d9003f8b07a468a704e0644a700e936c357c17dd45a"},
+    {file = "wrapt-1.17.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0f2a28eb35cf99d5f5bd12f5dd44a0f41d206db226535b37b0c60e9da162c3ed"},
+    {file = "wrapt-1.17.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:81b1289e99cf4bad07c23393ab447e5e96db0ab50974a280f7954b071d41b489"},
+    {file = "wrapt-1.17.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f2939cd4a2a52ca32bc0b359015718472d7f6de870760342e7ba295be9ebaf9"},
+    {file = "wrapt-1.17.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6a9653131bda68a1f029c52157fd81e11f07d485df55410401f745007bd6d339"},
+    {file = "wrapt-1.17.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4e4b4385363de9052dac1a67bfb535c376f3d19c238b5f36bddc95efae15e12d"},
+    {file = "wrapt-1.17.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bdf62d25234290db1837875d4dceb2151e4ea7f9fff2ed41c0fde23ed542eb5b"},
+    {file = "wrapt-1.17.0-cp311-cp311-win32.whl", hash = "sha256:5d8fd17635b262448ab8f99230fe4dac991af1dabdbb92f7a70a6afac8a7e346"},
+    {file = "wrapt-1.17.0-cp311-cp311-win_amd64.whl", hash = "sha256:92a3d214d5e53cb1db8b015f30d544bc9d3f7179a05feb8f16df713cecc2620a"},
+    {file = "wrapt-1.17.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:89fc28495896097622c3fc238915c79365dd0ede02f9a82ce436b13bd0ab7569"},
+    {file = "wrapt-1.17.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:875d240fdbdbe9e11f9831901fb8719da0bd4e6131f83aa9f69b96d18fae7504"},
+    {file = "wrapt-1.17.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e5ed16d95fd142e9c72b6c10b06514ad30e846a0d0917ab406186541fe68b451"},
+    {file = "wrapt-1.17.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18b956061b8db634120b58f668592a772e87e2e78bc1f6a906cfcaa0cc7991c1"},
+    {file = "wrapt-1.17.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:daba396199399ccabafbfc509037ac635a6bc18510ad1add8fd16d4739cdd106"},
+    {file = "wrapt-1.17.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4d63f4d446e10ad19ed01188d6c1e1bb134cde8c18b0aa2acfd973d41fcc5ada"},
+    {file = "wrapt-1.17.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8a5e7cc39a45fc430af1aefc4d77ee6bad72c5bcdb1322cfde852c15192b8bd4"},
+    {file = "wrapt-1.17.0-cp312-cp312-win32.whl", hash = "sha256:0a0a1a1ec28b641f2a3a2c35cbe86c00051c04fffcfcc577ffcdd707df3f8635"},
+    {file = "wrapt-1.17.0-cp312-cp312-win_amd64.whl", hash = "sha256:3c34f6896a01b84bab196f7119770fd8466c8ae3dfa73c59c0bb281e7b588ce7"},
+    {file = "wrapt-1.17.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:714c12485aa52efbc0fc0ade1e9ab3a70343db82627f90f2ecbc898fdf0bb181"},
+    {file = "wrapt-1.17.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da427d311782324a376cacb47c1a4adc43f99fd9d996ffc1b3e8529c4074d393"},
+    {file = "wrapt-1.17.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ba1739fb38441a27a676f4de4123d3e858e494fac05868b7a281c0a383c098f4"},
+    {file = "wrapt-1.17.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e711fc1acc7468463bc084d1b68561e40d1eaa135d8c509a65dd534403d83d7b"},
+    {file = "wrapt-1.17.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:140ea00c87fafc42739bd74a94a5a9003f8e72c27c47cd4f61d8e05e6dec8721"},
+    {file = "wrapt-1.17.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:73a96fd11d2b2e77d623a7f26e004cc31f131a365add1ce1ce9a19e55a1eef90"},
+    {file = "wrapt-1.17.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0b48554952f0f387984da81ccfa73b62e52817a4386d070c75e4db7d43a28c4a"},
+    {file = "wrapt-1.17.0-cp313-cp313-win32.whl", hash = "sha256:498fec8da10e3e62edd1e7368f4b24aa362ac0ad931e678332d1b209aec93045"},
+    {file = "wrapt-1.17.0-cp313-cp313-win_amd64.whl", hash = "sha256:fd136bb85f4568fffca995bd3c8d52080b1e5b225dbf1c2b17b66b4c5fa02838"},
+    {file = "wrapt-1.17.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:17fcf043d0b4724858f25b8826c36e08f9fb2e475410bece0ec44a22d533da9b"},
+    {file = "wrapt-1.17.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4a557d97f12813dc5e18dad9fa765ae44ddd56a672bb5de4825527c847d6379"},
+    {file = "wrapt-1.17.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0229b247b0fc7dee0d36176cbb79dbaf2a9eb7ecc50ec3121f40ef443155fb1d"},
+    {file = "wrapt-1.17.0-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8425cfce27b8b20c9b89d77fb50e368d8306a90bf2b6eef2cdf5cd5083adf83f"},
+    {file = "wrapt-1.17.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9c900108df470060174108012de06d45f514aa4ec21a191e7ab42988ff42a86c"},
+    {file = "wrapt-1.17.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:4e547b447073fc0dbfcbff15154c1be8823d10dab4ad401bdb1575e3fdedff1b"},
+    {file = "wrapt-1.17.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:914f66f3b6fc7b915d46c1cc424bc2441841083de01b90f9e81109c9759e43ab"},
+    {file = "wrapt-1.17.0-cp313-cp313t-win32.whl", hash = "sha256:a4192b45dff127c7d69b3bdfb4d3e47b64179a0b9900b6351859f3001397dabf"},
+    {file = "wrapt-1.17.0-cp313-cp313t-win_amd64.whl", hash = "sha256:4f643df3d4419ea3f856c5c3f40fec1d65ea2e89ec812c83f7767c8730f9827a"},
+    {file = "wrapt-1.17.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:69c40d4655e078ede067a7095544bcec5a963566e17503e75a3a3e0fe2803b13"},
+    {file = "wrapt-1.17.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f495b6754358979379f84534f8dd7a43ff8cff2558dcdea4a148a6e713a758f"},
+    {file = "wrapt-1.17.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:baa7ef4e0886a6f482e00d1d5bcd37c201b383f1d314643dfb0367169f94f04c"},
+    {file = "wrapt-1.17.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8fc931382e56627ec4acb01e09ce66e5c03c384ca52606111cee50d931a342d"},
+    {file = "wrapt-1.17.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:8f8909cdb9f1b237786c09a810e24ee5e15ef17019f7cecb207ce205b9b5fcce"},
+    {file = "wrapt-1.17.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:ad47b095f0bdc5585bced35bd088cbfe4177236c7df9984b3cc46b391cc60627"},
+    {file = "wrapt-1.17.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:948a9bd0fb2c5120457b07e59c8d7210cbc8703243225dbd78f4dfc13c8d2d1f"},
+    {file = "wrapt-1.17.0-cp38-cp38-win32.whl", hash = "sha256:5ae271862b2142f4bc687bdbfcc942e2473a89999a54231aa1c2c676e28f29ea"},
+    {file = "wrapt-1.17.0-cp38-cp38-win_amd64.whl", hash = "sha256:f335579a1b485c834849e9075191c9898e0731af45705c2ebf70e0cd5d58beed"},
+    {file = "wrapt-1.17.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:d751300b94e35b6016d4b1e7d0e7bbc3b5e1751e2405ef908316c2a9024008a1"},
+    {file = "wrapt-1.17.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7264cbb4a18dc4acfd73b63e4bcfec9c9802614572025bdd44d0721983fc1d9c"},
+    {file = "wrapt-1.17.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:33539c6f5b96cf0b1105a0ff4cf5db9332e773bb521cc804a90e58dc49b10578"},
+    {file = "wrapt-1.17.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c30970bdee1cad6a8da2044febd824ef6dc4cc0b19e39af3085c763fdec7de33"},
+    {file = "wrapt-1.17.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:bc7f729a72b16ee21795a943f85c6244971724819819a41ddbaeb691b2dd85ad"},
+    {file = "wrapt-1.17.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:6ff02a91c4fc9b6a94e1c9c20f62ea06a7e375f42fe57587f004d1078ac86ca9"},
+    {file = "wrapt-1.17.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2dfb7cff84e72e7bf975b06b4989477873dcf160b2fd89959c629535df53d4e0"},
+    {file = "wrapt-1.17.0-cp39-cp39-win32.whl", hash = "sha256:2399408ac33ffd5b200480ee858baa58d77dd30e0dd0cab6a8a9547135f30a88"},
+    {file = "wrapt-1.17.0-cp39-cp39-win_amd64.whl", hash = "sha256:4f763a29ee6a20c529496a20a7bcb16a73de27f5da6a843249c7047daf135977"},
+    {file = "wrapt-1.17.0-py3-none-any.whl", hash = "sha256:d2c63b93548eda58abf5188e505ffed0229bf675f7c3090f8e36ad55b8cbc371"},
+    {file = "wrapt-1.17.0.tar.gz", hash = "sha256:16187aa2317c731170a88ef35e8937ae0f533c402872c1ee5e6d079fcf320801"},
 ]
 
 [[package]]
@@ -2064,4 +2401,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "6c4ce480ad4e6f2cf11ec7e00e3758302c338f957e4db67026a206198ebb7cd7"
+content-hash = "400875672adc220f22c7a66bb27e1090f2a355b170dd59cd1c43e6d5477194bc"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,31 +1,106 @@
 [project]
 name = "openshift_perfscale_api"
+requires-python = "^3.9"
+dynamic = ["dependencies"]
 version = "0.1.1"
 description = "Python transformer of OpenShift performance and scale test results"
 authors = [{name = "mleader", email = "mleader@redhat.com"}]
 
+[tool.poetry]
+packages = [
+    { include = "app" }
+]
+
 [tool.poetry.dependencies]
 aiohttp = "^3.7.4"
-atlassian-python-api = "^3.41.9"
+atlassian-python-api = "^3.41.9.20"
 cryptography = "^3.4.8"
 elasticsearch = "7.13.4"
 fastapi = "^0.104.1"
 httptools = "^0.2.0"
 httpx = "^0.18.1"
+numpy = "1.26.4"
 orjson = "^3.5.3"
 pandas = "1.2.4"
 pydantic = "2.3.0"
 python = "^3.9"
 python-keycloak = "^3.12.0"
+pytest = "^8.3.4"
+pytest-asyncio = "^0.24"
+pytest-cov = "^6.0"
 semver = "2.13.0"
 splunk-sdk = "2.0.1"
+tox = "^4.23.2"
 trio = "^0.18.0"
-uvicorn = "^0.14.0"
+uvicorn = "^0.32.0"
 uvloop = "^0.15.2"
 vyper-config = "1.0.0"
 
 [tool.poetry.group.dev.dependencies]
 watchgod = "^0.7"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+
+[tool.isort]
+profile = "black"                 # black-compatible (e.g., trailing comma)
+known_first_party = ["app"]       # separate our headers into a section
+multi_line_output = 3             # "hanging" indent with dedented paren
+force_sort_within_sections = true # don't separate import vs from
+order_by_type = false             # sort alphabetic regardless of case
+
+[tool.tox]
+requires = ["tox>=4.19"]
+env_list = ["unit", "format", "lint", "isort"]
+
+[tool.tox.env_run_base]
+description = "Run test under {base_python}"
+base_python = ["python3.9"]
+deps = [
+    "pytest",
+    "pytest-asyncio",
+    "pytest-cov",
+    "coverage",
+]
+set_env.COVERAGE = { replace = "env", name = "COVERAGE", default = "/var/tmp/{env:USER}" }
+allowlist_externals = ["bash", "echo", "coverage"]
+commands = [
+    ["echo", "{env:COVERAGE}"],
+    ["pip", "list"],
+    ["pytest", "-s", "--cov-branch", "--cov=app", "tests"],
+    ["coverage", "html", "--directory={env:COVERAGE}/html"],
+    ["bash", "-c", "coverage report --format=markdown >{env:COVERAGE}/coverage.txt"],
+]
+
+[tool.tox.env.format]
+description = "check code format"
+skip_install = true
+deps = ["black"]
+commands = [["black", "--check", { replace = "posargs", default = ["app", "tests"], extend = true} ]]
+
+[tool.tox.env.isort]
+description = "check order of imports"
+skip_install = true
+deps = ["isort"]
+commands = [["isort", "--check", { replace = "posargs", default = ["app", "tests"], extend = true} ]]
+
+[tool.tox.env.lint]
+description = "check code"
+skip_install = true
+deps = ["flake8"]
+commands = [["flake8", { replace = "posargs", default = ["app", "tests"], extend = true} ]]
+
+[tool.coverage.run]
+branch = true
+cover_pylib = true
+data_file = "${COVERAGE}/coverage.db"
+parallel = true
+relative_files = true
+
+[tool.coverage.report]
+include_namespace_packages = true
+skip_empty = true
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -68,7 +68,7 @@ allowlist_externals = ["bash", "echo", "coverage"]
 commands = [
     ["echo", "{env:COVERAGE}"],
     ["pip", "list"],
-    ["pytest", "-s", "--cov-branch", "--cov=app", "tests"],
+    ["pytest", "-s", "--cov-branch", "--cov=app", "{posargs}", "tests"],
     ["coverage", "html", "--directory={env:COVERAGE}/html"],
     ["bash", "-c", "coverage report --format=markdown >{env:COVERAGE}/coverage.txt"],
 ]

--- a/backend/tests/fake_elastic.py
+++ b/backend/tests/fake_elastic.py
@@ -1,12 +1,36 @@
+from collections import defaultdict
+from dataclasses import dataclass
 from typing import Any, Optional, Union
 
 from elasticsearch import AsyncElasticsearch
+
+
+@dataclass
+class Request:
+    index: str
+    body: dict[str, Any]
+    doc_type: Optional[str] = None
+    params: Optional[Any] = None
+    headers: Optional[Any] = None
+    kwargs: Optional[dict[str, Any]] = None
+
+    def __eq__(self, other) -> bool:
+        iok = self.index == other.index
+        bok = self.body == other.body
+        dok = self.doc_type == other.doc_type
+        pok = self.params == other.params
+        hok = self.headers == other.headers
+
+        # make empty dict and None match
+        kok = (not self.kwargs and not other.kwargs) or self.kwargs == other.kwargs
+        return iok and bok and dok and pok and hok and kok
 
 
 class FakeAsyncElasticsearch(AsyncElasticsearch):
     hosts: Union[str, list[str]]
     args: dict[str, Any]
     closed: bool
+    requests: list[Request]
 
     # This fake doesn't try to mimic Opensearch query and aggregation logic:
     # instead, the "data" is pre-loaded with a JSON response body that will
@@ -18,20 +42,37 @@ class FakeAsyncElasticsearch(AsyncElasticsearch):
         self.hosts = hosts
         self.args = kwargs
         self.closed = False
-        self.data = {}
+        self.data = defaultdict(list)
+        self.requests = []
 
     # Testing helpers to manage fake searches
     def set_query(
         self,
         root_index: str,
         hit_list: Optional[list[dict[str, Any]]] = None,
-        aggregation_list: Optional[dict[str, Any]] = None,
+        aggregations: Optional[dict[str, Any]] = None,
         version: int = 7,
+        repeat: int = 1,
     ):
+        """Add a canned response to an Opensearch query
+
+        The overall response and items in the hit and aggregation lists will be
+        augmented with the usual boilerplate.
+
+        Multiple returns for a single index can be queued, in order, via
+        successive calls. To return the same result on multiple calls, specify
+        a "repeat" value greater than 1.
+
+        Args:
+            root_index: CDM index name (run, period, etc)
+            hit_list: list of hit objects to be returned
+            aggregation_list: list of aggregation objects to return
+            version: CDM version
+            repeat:
+        """
         ver = f"v{version:d}dev"
         index = f"cdm{ver}-{root_index}"
         hits = []
-        aggregations = None
         if hit_list:
             for d in hit_list:
                 source = d
@@ -44,16 +85,18 @@ class FakeAsyncElasticsearch(AsyncElasticsearch):
                         "_source": source,
                     }
                 )
-        if aggregation_list:
-            aggregations = {
-                k: {
-                    "doc_count_error_upper_bound": 0,
-                    "sum_other_doc_count": 0,
-                    "buckets": v,
-                }
-                for k, v in aggregation_list.items()
-            }
-        self.data[index] = {
+        aggregate_response = {}
+        if aggregations:
+            for agg, val in aggregations.items():
+                if isinstance(val, list):
+                    aggregate_response[agg] = {
+                        "doc_count_error_upper_bound": 0,
+                        "sum_other_doc_count": 0,
+                        "buckets": val,
+                    }
+                else:
+                    aggregate_response[agg] = val
+        response = {
             "took": 1,
             "timed_out": False,
             "_shards": {"total": 1, "successful": 1, "skipped": 0, "failed": 0},
@@ -63,8 +106,10 @@ class FakeAsyncElasticsearch(AsyncElasticsearch):
                 "hits": hits,
             },
         }
-        if aggregations:
-            self.data[index]["aggregations"] = aggregations
+        if aggregate_response:
+            response["aggregations"] = aggregate_response
+        for c in range(repeat):
+            self.data[index].append(response)
 
     # Faked AsyncElasticsearch methods
     async def close(self):
@@ -79,9 +124,34 @@ class FakeAsyncElasticsearch(AsyncElasticsearch):
     async def search(
         self, body=None, index=None, doc_type=None, params=None, headers=None, **kwargs
     ):
-        if index in self.data:
-            target = self.data[index]
-            del self.data[index]
+        """Return a canned response to a search query.
+
+        Args:
+            body: query body
+            index: Opensearch index name
+            doc_type: document type (rarely used)
+            params: Opensearch search parameters (rarely used)
+            headers: HTTP headers (rarely used)
+            kwargs: whatever else you might pass to search
+
+        Only the index is used here; to verify the correct Opensearch query
+        bodies and parameters, the full request is recorded for inspection.
+
+        Return:
+            A JSON dict with the first canned result for the index, or an error
+        """
+        self.requests.append(
+            Request(
+                index=index,
+                body=body,
+                doc_type=doc_type,
+                params=params,
+                headers=headers,
+                kwargs=kwargs,
+            )
+        )
+        if index in self.data and len(self.data[index]) > 0:
+            target = self.data[index].pop(0)
             return target
         return {
             "error": {

--- a/backend/tests/fake_elastic.py
+++ b/backend/tests/fake_elastic.py
@@ -1,0 +1,106 @@
+from typing import Any, Optional, Union
+
+from elasticsearch import AsyncElasticsearch
+
+
+class FakeAsyncElasticsearch(AsyncElasticsearch):
+    hosts: Union[str, list[str]]
+    args: dict[str, Any]
+    closed: bool
+
+    # This fake doesn't try to mimic Opensearch query and aggregation logic:
+    # instead, the "data" is pre-loaded with a JSON response body that will
+    # be returned on an "index" match. (This means that any external call we
+    # need to mock has a single query against any one index!)
+    data: dict[str, Any]
+
+    def __init__(self, hosts: Union[str, list[str]], **kwargs):
+        self.hosts = hosts
+        self.args = kwargs
+        self.closed = False
+        self.data = {}
+
+    # Testing helpers to manage fake searches
+    def set_query(
+        self,
+        root_index: str,
+        hit_list: Optional[list[dict[str, Any]]] = None,
+        aggregation_list: Optional[dict[str, Any]] = None,
+        version: int = 7,
+    ):
+        ver = f"v{version:d}dev"
+        index = f"cdm{ver}-{root_index}"
+        hits = []
+        aggregations = None
+        if hit_list:
+            for d in hit_list:
+                source = d
+                source["cdm"] = {"ver": ver}
+                hits.append(
+                    {
+                        "_index": index,
+                        "_id": "random_string",
+                        "_score": 1.0,
+                        "_source": source,
+                    }
+                )
+        if aggregation_list:
+            aggregations = {
+                k: {
+                    "doc_count_error_upper_bound": 0,
+                    "sum_other_doc_count": 0,
+                    "buckets": v,
+                }
+                for k, v in aggregation_list.items()
+            }
+        self.data[index] = {
+            "took": 1,
+            "timed_out": False,
+            "_shards": {"total": 1, "successful": 1, "skipped": 0, "failed": 0},
+            "hits": {
+                "total": {"value": len(hits), "relation": "eq"},
+                "max_score": 1.0,
+                "hits": hits,
+            },
+        }
+        if aggregations:
+            self.data[index]["aggregations"] = aggregations
+
+    # Faked AsyncElasticsearch methods
+    async def close(self):
+        self.closed = True
+
+    async def info(self, **kwargs):
+        pass
+
+    async def ping(self, **kwargs):
+        return True
+
+    async def search(
+        self, body=None, index=None, doc_type=None, params=None, headers=None, **kwargs
+    ):
+        if index in self.data:
+            target = self.data[index]
+            del self.data[index]
+            return target
+        return {
+            "error": {
+                "root_cause": [
+                    {
+                        "type": "index_not_found_exception",
+                        "reason": f"no such index [{index}]",
+                        "index": index,
+                        "resource.id": index,
+                        "resource.type": "index_or_alias",
+                        "index_uuid": "_na_",
+                    },
+                ],
+                "type": "index_not_found_exception",
+                "reason": f"no such index [{index}]",
+                "index": index,
+                "resource.id": index,
+                "resource.type": "index_or_alias",
+                "index_uuid": "_na_",
+            },
+            "status": 404,
+        }

--- a/backend/tests/test_crucible.py
+++ b/backend/tests/test_crucible.py
@@ -1,0 +1,265 @@
+from elasticsearch import AsyncElasticsearch
+from fastapi import HTTPException
+import pytest
+from vyper import Vyper
+
+import app.config
+from app.services.crucible_svc import CommonParams, CrucibleService, Parser
+from tests.fake_elastic import FakeAsyncElasticsearch
+
+
+@pytest.fixture
+def fake_config(monkeypatch):
+    """Provide a fake configuration"""
+
+    vyper = Vyper(config_name="ocpperf")
+    vyper.set("TEST.url", "http://elastic.example.com:9200")
+    monkeypatch.setattr("app.config.get_config", lambda: vyper)
+
+
+@pytest.fixture
+def fake_elastic(monkeypatch, fake_config):
+    """Replace the actual elastic client with a fake"""
+
+    monkeypatch.setattr(
+        "app.services.crucible_svc.AsyncElasticsearch", FakeAsyncElasticsearch
+    )
+
+
+@pytest.fixture
+async def fake_crucible(fake_elastic):
+    crucible = CrucibleService("TEST")
+    yield crucible
+    await crucible.close()
+
+
+class TestParser:
+
+    def test_parse_normal(self):
+        """Test successful parsing of three terms"""
+
+        t = Parser("foo:bar=x")
+        assert ("foo", ":") == t._next_token([":", "="])
+        assert ("bar", "=") == t._next_token([":", "="])
+        assert ("x", None) == t._next_token([":", "="], optional=True)
+
+    def test_parse_missing(self):
+        """Test exception when a delimiter is missing"""
+
+        t = Parser("foo:bar=x")
+        assert ("foo", ":") == t._next_token([":", "="])
+        assert ("bar", "=") == t._next_token([":", "="])
+        with pytest.raises(HTTPException) as e:
+            t._next_token(delimiters=[":", "="])
+        assert 400 == e.value.status_code
+        assert "Missing delimiter from :,= after 'x'" == e.value.detail
+
+    def test_parse_quoted(self):
+        """Test acceptance of quoted terms"""
+
+        t = Parser("'foo':\"bar\"='x'")
+        assert ("foo", ":") == t._next_token([":", "="])
+        assert ("bar", "=") == t._next_token([":", "="])
+        assert ("x", None) == t._next_token([":", "="], optional=True)
+
+    def test_parse_bad_quoted(self):
+        """Test detection of badly paired quotes"""
+
+        t = Parser("'foo':'bar\"='x'")
+        assert ("foo", ":") == t._next_token([":", "="])
+        with pytest.raises(HTTPException) as e:
+            t._next_token([":", "="])
+        assert 400 == e.value.status_code
+        assert "Unterminated quote at '\\'foo\\':\\'bar[\"]=\\'x\\''" == e.value.detail
+
+
+class TestCommonParams:
+
+    def test_one(self):
+        """Test that we drop unique params"""
+
+        c = CommonParams()
+        c.add({"one": 1, "two": 2})
+        c.add({"one": 1, "three": 3})
+        c.add({"one": 1, "two": 5})
+        assert {"one": 1} == c.render()
+
+
+class TestCrucible:
+
+    async def test_create(self, fake_crucible):
+        """Create and close a CrucibleService instance"""
+
+        assert fake_crucible
+        assert isinstance(fake_crucible, CrucibleService)
+        assert isinstance(fake_crucible.elastic, AsyncElasticsearch)
+        assert app.config.get_config().get("TEST.url") == fake_crucible.url
+        elastic = fake_crucible.elastic
+        await fake_crucible.close()
+        assert fake_crucible.elastic is None
+        assert elastic.closed
+
+    def test_no_hits(self):
+        """Expect an exception because 'hits' is missing"""
+
+        with pytest.raises(HTTPException) as e:
+            for a in CrucibleService._hits({}):
+                assert f"Unexpected result {type(a)}"
+        assert 500 == e.value.status_code
+        assert "Attempt to iterate hits for {}" == e.value.detail
+
+    def test_empty_hits(self):
+        """Expect successful iteration of no hits"""
+
+        for a in CrucibleService._hits({"hits": {"hits": []}}):
+            assert f"Unexpected result {type(a)}"
+
+    def test_hits(self):
+        """Test that iteration through hits works"""
+
+        expected = [{"a": 1}, {"b": 1}]
+        payload = [{"_source": a} for a in expected]
+        assert expected == list(CrucibleService._hits({"hits": {"hits": payload}}))
+
+    def test_hits_fields(self):
+        """Test that iteration through hit fields works"""
+
+        expected = [{"a": 1}, {"b": 1}]
+        payload = [{"_source": {"f": a, "e": 1}} for a in expected]
+        assert expected == list(
+            CrucibleService._hits({"hits": {"hits": payload}}, ["f"])
+        )
+
+    async def test_metric_ids_none(self, fake_crucible):
+        """A simple query for failure matching metric IDs"""
+
+        fake_crucible.elastic.set_query("metric_desc", [])
+        with pytest.raises(HTTPException) as e:
+            await fake_crucible._get_metric_ids("runid", "source::type")
+        assert 400 == e.value.status_code
+        assert "No matches for source::type" == e.value.detail
+
+    @pytest.mark.parametrize(
+        "found,expected",
+        (
+            (
+                [
+                    {"metric_desc": {"id": "one-metric"}},
+                ],
+                ["one-metric"],
+            ),
+            (
+                [
+                    {"metric_desc": {"id": "one-metric"}},
+                    {"metric_desc": {"id": "two-metric"}},
+                ],
+                ["one-metric", "two-metric"],
+            ),
+        ),
+    )
+    async def test_metric_ids(self, fake_crucible, found, expected):
+        """A simple query for matching metric IDs"""
+
+        fake_crucible.elastic.set_query("metric_desc", found)
+        assert expected == await fake_crucible._get_metric_ids(
+            "runid",
+            "source::type",
+            aggregate=len(expected) > 1,
+        )
+
+    async def test_run_filters(self, fake_crucible):
+        """Test aggregations
+
+        This is the "simplest" aggregation-based query, but we need to define
+        fake aggregations for the tag, param, and run indices.
+        """
+
+        fake_crucible.elastic.set_query(
+            "tag",
+            aggregation_list={
+                "key": [
+                    {
+                        "key": "topology",
+                        "doc_count": 25,
+                        "values": {
+                            "doc_count_error_upper_bound": 0,
+                            "sum_other_doc_count": 0,
+                            "buckets": [],
+                        },
+                    },
+                    {
+                        "key": "accelerator",
+                        "doc_count": 19,
+                        "values": {
+                            "doc_count_error_upper_bound": 0,
+                            "sum_other_doc_count": 0,
+                            "buckets": [
+                                {"key": "A100", "doc_count": 5},
+                                {"key": "L40S", "doc_count": 2},
+                            ],
+                        },
+                    },
+                    {
+                        "key": "project",
+                        "doc_count": 19,
+                        "values": {
+                            "doc_count_error_upper_bound": 0,
+                            "sum_other_doc_count": 0,
+                            "buckets": [
+                                {"key": "rhelai", "doc_count": 1},
+                                {"key": "rhosai", "doc_count": 2},
+                            ],
+                        },
+                    },
+                ]
+            },
+        )
+        fake_crucible.elastic.set_query(
+            "param",
+            aggregation_list={
+                "key": [
+                    {
+                        "key": "bucket",
+                        "doc_count": 25,
+                        "values": {
+                            "doc_count_error_upper_bound": 0,
+                            "sum_other_doc_count": 0,
+                            "buckets": [{"key": 200, "doc_count": 30}],
+                        },
+                    },
+                ]
+            },
+        )
+        fake_crucible.elastic.set_query(
+            "run",
+            aggregation_list={
+                "begin": [{"key": 123456789, "doc_count": 1}],
+                "benchmark": [{"key": "ilab", "doc_count": 25}],
+                "desc": [],
+                "email": [
+                    {"key": "me@example.com", "doc_count": 10},
+                    {"key": "you@example.com", "doc_count": 15},
+                ],
+                "end": [{"key": 1234, "doc_count": 10}],
+                "harness": [],
+                "host": [
+                    {"key": "one.example.com", "doc_count": 5},
+                    {"key": "two.example.com", "doc_count": 20},
+                ],
+                "id": [],
+                "name": [],
+                "source": [],
+            },
+        )
+        filters = await fake_crucible.get_run_filters()
+
+        # Array ordering is not reliable, so we need to sort
+        assert sorted(filters.keys()) == ["param", "run", "tag"]
+        assert sorted(filters["tag"].keys()) == ["accelerator", "project"]
+        assert sorted(filters["param"].keys()) == ["bucket"]
+        assert sorted(filters["run"].keys()) == ["benchmark", "email", "host"]
+        assert sorted(filters["tag"]["accelerator"]) == ["A100", "L40S"]
+        assert sorted(filters["param"]["bucket"]) == [200]
+        assert sorted(filters["run"]["benchmark"]) == ["ilab"]
+        assert sorted(filters["run"]["email"]) == ["me@example.com", "you@example.com"]
+        assert sorted(filters["run"]["host"]) == ["one.example.com", "two.example.com"]

--- a/backend/tests/test_crucible.py
+++ b/backend/tests/test_crucible.py
@@ -1,11 +1,21 @@
+from collections import defaultdict
+from datetime import datetime, timezone
+import json
+
 from elasticsearch import AsyncElasticsearch
 from fastapi import HTTPException
 import pytest
-from vyper import Vyper
 
 import app.config
-from app.services.crucible_svc import CommonParams, CrucibleService, Parser
-from tests.fake_elastic import FakeAsyncElasticsearch
+from app.services.crucible_svc import (
+    CommonParams,
+    CrucibleService,
+    Graph,
+    GraphList,
+    Parser,
+)
+from tests.fake_elastic import FakeAsyncElasticsearch, Request
+from vyper import Vyper
 
 
 @pytest.fixture
@@ -85,19 +95,87 @@ class TestCommonParams:
         assert {"one": 1} == c.render()
 
 
-class TestCrucible:
+class TestList:
 
-    async def test_create(self, fake_crucible):
-        """Create and close a CrucibleService instance"""
+    @pytest.mark.parametrize(
+        "input,output",
+        (
+            (None, []),
+            (["a"], ["a"]),
+            (["a", "b"], ["a", "b"]),
+            (["a,b"], ["a", "b"]),
+            (["a", "b,c", "d"], ["a", "b", "c", "d"]),
+        ),
+    )
+    def test_split_empty(self, input, output):
+        assert output == CrucibleService._split_list(input)
 
-        assert fake_crucible
-        assert isinstance(fake_crucible, CrucibleService)
-        assert isinstance(fake_crucible.elastic, AsyncElasticsearch)
-        assert app.config.get_config().get("TEST.url") == fake_crucible.url
-        elastic = fake_crucible.elastic
-        await fake_crucible.close()
-        assert fake_crucible.elastic is None
-        assert elastic.closed
+
+class TestFormatters:
+
+    @pytest.mark.parametrize(
+        "input",
+        (
+            "2024-09-12 18:29:35.123000+00:00",
+            datetime.fromisoformat("2024-09-12 18:29:35.123000+00:00"),
+            "1726165775123",
+            1726165775123,
+        ),
+    )
+    def test_normalize_date(self, input):
+        assert 1726165775123 == CrucibleService._normalize_date(input)
+
+    def test_normalize_date_bad(self):
+        with pytest.raises(HTTPException) as e:
+            CrucibleService._normalize_date([])
+        assert 400 == e.value.status_code
+        assert "Date representation [] is not a date string or timestamp"
+
+    @pytest.mark.parametrize(
+        "input,output",
+        (
+            ("abc", "1970-01-01 00:00:00+00:00"),
+            ("1726165775123", "2024-09-12 18:29:35.123000+00:00"),
+            (1726165775123, "2024-09-12 18:29:35.123000+00:00"),
+        ),
+    )
+    def test_format_timestamp(self, input, output):
+        assert output == CrucibleService._format_timestamp(input)
+
+    def test_format_data(self):
+        begin = 1726165775123
+        duration = 10244
+        raw = {
+            "begin": str(begin),
+            "end": str(begin + duration),
+            "duration": str(duration),
+            "value": "100.3",
+        }
+        expect = {
+            "begin": "2024-09-12 18:29:35.123000+00:00",
+            "end": "2024-09-12 18:29:45.367000+00:00",
+            "duration": 10.244,
+            "value": 100.3,
+        }
+        assert expect == CrucibleService._format_data(raw)
+
+    def test_format_period(self):
+        raw = {
+            "begin": "1726165775123",
+            "end": "1726165785234",
+            "id": "ABC-123",
+            "name": "measurement",
+        }
+        expect = {
+            "begin": "2024-09-12 18:29:35.123000+00:00",
+            "end": "2024-09-12 18:29:45.234000+00:00",
+            "id": "ABC-123",
+            "name": "measurement",
+        }
+        assert expect == CrucibleService._format_period(raw)
+
+
+class TestHits:
 
     def test_no_hits(self):
         """Expect an exception because 'hits' is missing"""
@@ -112,7 +190,7 @@ class TestCrucible:
         """Expect successful iteration of no hits"""
 
         for a in CrucibleService._hits({"hits": {"hits": []}}):
-            assert f"Unexpected result {type(a)}"
+            assert f"Unexpected result {a}"
 
     def test_hits(self):
         """Test that iteration through hits works"""
@@ -130,6 +208,371 @@ class TestCrucible:
             CrucibleService._hits({"hits": {"hits": payload}}, ["f"])
         )
 
+
+class TestAggregates:
+
+    def test_no_aggregations(self):
+        """Expect an exception if the aggregations are missing"""
+        with pytest.raises(HTTPException) as e:
+            for a in CrucibleService._aggs({}, "agg"):
+                assert f"Unexpected result {a}"
+        assert 500 == e.value.status_code
+        assert "Attempt to iterate missing aggregations for {}" == e.value.detail
+
+    def test_missing_agg(self):
+        """Expect an exception if the aggregations are missing"""
+
+        payload = {"aggregations": {}}
+        with pytest.raises(HTTPException) as e:
+            for a in CrucibleService._aggs(payload, "agg"):
+                assert f"Unexpected result {a}"
+        assert 500 == e.value.status_code
+        assert (
+            f"Attempt to iterate missing aggregation 'agg' for {payload}"
+            == e.value.detail
+        )
+
+    def test_empty_aggs(self):
+        """Expect successful iteration of no aggregation data"""
+
+        for a in CrucibleService._aggs(
+            {"aggregations": {"agg": {"buckets": []}}}, "agg"
+        ):
+            assert f"Unexpected result {a}"
+
+    def test_aggs(self):
+        """Test that iteration through aggregations works"""
+
+        expected = [{"key": 1, "doc_count": 2}, {"key": 2, "doc_count": 5}]
+        payload = {
+            "hits": {"total": {"value": 0}, "hits": []},
+            "aggregations": {
+                "agg": {
+                    "buckets": [{"key": 1, "doc_count": 2}, {"key": 2, "doc_count": 5}]
+                }
+            },
+        }
+        assert expected == list(CrucibleService._aggs(payload, "agg"))
+
+
+class TestFilterBuilders:
+
+    @pytest.mark.parametrize(
+        "filters,terms",
+        (
+            (
+                ["param:v=1", "tag:x='one two'", "run:email='d@e.c'"],
+                (
+                    [
+                        {
+                            "dis_max": {
+                                "queries": [
+                                    {
+                                        "bool": {
+                                            "must": [
+                                                {
+                                                    "term": {
+                                                        "param.arg": "v",
+                                                    },
+                                                },
+                                                {
+                                                    "term": {
+                                                        "param.val": "1",
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                    [
+                        {
+                            "dis_max": {
+                                "queries": [
+                                    {
+                                        "bool": {
+                                            "must": [
+                                                {
+                                                    "term": {
+                                                        "tag.name": "x",
+                                                    },
+                                                },
+                                                {
+                                                    "term": {
+                                                        "tag.val": "one two",
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                    [
+                        {
+                            "term": {
+                                "run.email": "d@e.c",
+                            },
+                        },
+                    ],
+                ),
+            ),
+            (
+                ["param:v~a"],
+                (
+                    [
+                        {
+                            "dis_max": {
+                                "queries": [
+                                    {
+                                        "bool": {
+                                            "must": [
+                                                {
+                                                    "term": {
+                                                        "param.arg": "v",
+                                                    },
+                                                },
+                                                {
+                                                    "regexp": {
+                                                        "param.val": ".*a.*",
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                    None,
+                    None,
+                ),
+            ),
+            (
+                ["tag:v~a"],
+                (
+                    None,
+                    [
+                        {
+                            "dis_max": {
+                                "queries": [
+                                    {
+                                        "bool": {
+                                            "must": [
+                                                {
+                                                    "term": {
+                                                        "tag.name": "v",
+                                                    },
+                                                },
+                                                {
+                                                    "regexp": {
+                                                        "tag.val": ".*a.*",
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                    None,
+                ),
+            ),
+        ),
+    )
+    def test_build_filter_options(self, filters, terms):
+        assert terms == CrucibleService._build_filter_options(filters)
+
+    def test_build_filter_bad_key(self):
+        with pytest.raises(HTTPException) as e:
+            CrucibleService._build_filter_options(["foobar:x=y"])
+        assert 400 == e.value.status_code
+        assert "unknown filter namespace 'foobar'" == e.value.detail
+
+    def test_build_name_filters(self):
+        assert [
+            {"term": {"metric_desc.names.name": "1"}}
+        ] == CrucibleService._build_name_filters(["name=1"])
+
+    def test_build_name_filters_bad(self):
+        with pytest.raises(HTTPException) as e:
+            CrucibleService._build_name_filters(["xya:x"])
+        assert 400 == e.value.status_code
+        assert "Filter item 'xya:x' must be '<k>=<v>'"
+
+    @pytest.mark.parametrize("periods", ([], ["10"], ["10", "20"]))
+    def test_build_period_filters(self, periods):
+        expected = (
+            []
+            if not periods
+            else [
+                {
+                    "dis_max": {
+                        "queries": [
+                            {"bool": {"must_not": {"exists": {"field": "period"}}}},
+                            {"terms": {"period.id": periods}},
+                        ]
+                    }
+                }
+            ]
+        )
+        assert expected == CrucibleService._build_period_filters(periods)
+
+    @pytest.mark.parametrize(
+        "term,message",
+        (
+            (
+                "foo:asc",
+                "Sort key 'foo' must be one of begin,benchmark,desc,email,end,harness,host,id,name,source",
+            ),
+            ("email:up", "Sort direction 'up' must be one of asc,desc"),
+        ),
+    )
+    def test_build_sort_filters_error(self, term, message):
+        with pytest.raises(HTTPException) as exc:
+            CrucibleService._build_sort_terms([term])
+        assert 400 == exc.value.status_code
+        assert message == exc.value.detail
+
+    @pytest.mark.parametrize(
+        "sort,terms",
+        (
+            ([], (("run.begin", {"order": "asc"}),)),
+            (["email:asc"], (("run.email", {"order": "asc"}),)),
+            (
+                ["email:desc", "name:asc"],
+                (("run.email", {"order": "desc"}), ("run.name", {"order": "asc"})),
+            ),
+        ),
+    )
+    def test_build_sort_filters(self, sort, terms):
+        expected = [{t[0]: t[1]} for t in terms]
+        assert expected == CrucibleService._build_sort_terms(sort)
+
+    @pytest.mark.parametrize(
+        "periods,result",
+        (
+            (
+                [
+                    {
+                        "period": {
+                            "id": "one",
+                            "begin": "1733505934677",
+                            "end": "1733507347857",
+                        }
+                    }
+                ],
+                [
+                    {"range": {"metric_data.begin": {"gte": "1733505934677"}}},
+                    {"range": {"metric_data.end": {"lte": "1733507347857"}}},
+                ],
+            ),
+            (None, []),
+        ),
+    )
+    async def test_build_timestamp_filter(
+        self, fake_crucible: CrucibleService, periods, result
+    ):
+        plist = None
+        if periods:
+            fake_crucible.elastic.set_query("period", periods)
+            plist = [p["period"]["id"] for p in periods]
+        assert result == await fake_crucible._build_timestamp_range_filters(plist)
+
+    @pytest.mark.parametrize(
+        "period,name",
+        (
+            ({"period": {"id": "one"}}, "run None:None,iteration None,sample None"),
+            (
+                {
+                    "run": {"id": "rid", "benchmark": "test", "begin": "1234"},
+                    "iteration": {"id": "iid", "num": 1},
+                    "sample": {"id": "sid", "num": 1},
+                    "period": {"id": "one", "begin": "5423"},
+                },
+                "run test:1234,iteration 1,sample 1",
+            ),
+        ),
+    )
+    async def test_build_timestamp_filter_bad(
+        self, fake_crucible: CrucibleService, period, name
+    ):
+        fake_crucible.elastic.set_query("period", [period])
+        with pytest.raises(HTTPException) as exc:
+            await fake_crucible._build_timestamp_range_filters(["one"])
+        assert 422 == exc.value.status_code
+        assert (
+            f"Unable to compute '{name}' time range: the run is missing period timestamps"
+            == exc.value.detail
+        )
+
+
+class TestCrucible:
+
+    async def test_create(self, fake_crucible):
+        """Create and close a CrucibleService instance"""
+
+        assert fake_crucible
+        assert isinstance(fake_crucible, CrucibleService)
+        assert isinstance(fake_crucible.elastic, AsyncElasticsearch)
+        assert app.config.get_config().get("TEST.url") == fake_crucible.url
+        elastic = fake_crucible.elastic
+        await fake_crucible.close()
+        assert fake_crucible.elastic is None
+        assert elastic.closed
+
+    async def test_search_args(self, fake_crucible: CrucibleService):
+        await fake_crucible.search(
+            "run",
+            [{"term": "a"}],
+            [{"x": {"field": "a"}}],
+            [{"key": "asc"}],
+            "run",
+            42,
+            69,
+            x=2,
+            z=3,
+        )
+        assert [
+            Request(
+                "cdmv7dev-run",
+                {
+                    "_source": "run",
+                    "aggs": [
+                        {
+                            "x": {
+                                "field": "a",
+                            },
+                        },
+                    ],
+                    "from": 69,
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": "a",
+                                },
+                            ],
+                        },
+                    },
+                    "size": 42,
+                    "sort": [
+                        {
+                            "key": "asc",
+                        },
+                    ],
+                },
+                None,
+                None,
+                None,
+                {"x": 2, "z": 3},
+            )
+        ] == fake_crucible.elastic.requests
+
     async def test_metric_ids_none(self, fake_crucible):
         """A simple query for failure matching metric IDs"""
 
@@ -140,13 +583,21 @@ class TestCrucible:
         assert "No matches for source::type" == e.value.detail
 
     @pytest.mark.parametrize(
-        "found,expected",
+        "found,expected,aggregate",
         (
             (
                 [
                     {"metric_desc": {"id": "one-metric"}},
                 ],
                 ["one-metric"],
+                False,
+            ),
+            (
+                [
+                    {"metric_desc": {"id": "one-metric"}},
+                ],
+                ["one-metric"],
+                True,
             ),
             (
                 [
@@ -154,18 +605,63 @@ class TestCrucible:
                     {"metric_desc": {"id": "two-metric"}},
                 ],
                 ["one-metric", "two-metric"],
+                True,
             ),
         ),
     )
-    async def test_metric_ids(self, fake_crucible, found, expected):
+    async def test_metric_ids(self, fake_crucible, found, expected, aggregate):
         """A simple query for matching metric IDs"""
 
         fake_crucible.elastic.set_query("metric_desc", found)
         assert expected == await fake_crucible._get_metric_ids(
             "runid",
             "source::type",
-            aggregate=len(expected) > 1,
+            aggregate=aggregate,
         )
+
+    @pytest.mark.parametrize(
+        "found,message",
+        (
+            (
+                [
+                    {"metric_desc": {"id": "one-metric", "names": {"john": "yes"}}},
+                    {"metric_desc": {"id": "two-metric", "names": {"john": "no"}}},
+                ],
+                (2, [], {"john": ["no", "yes"]}),
+            ),
+            (
+                [
+                    {
+                        "period": {"id": "p1"},
+                        "metric_desc": {"id": "three-metric", "names": {"john": "yes"}},
+                    },
+                    {"metric_desc": {"id": "four-metric", "names": {"fred": "why"}}},
+                    {
+                        "period": {"id": "p2"},
+                        "metric_desc": {"id": "five-metric", "names": {"john": "sure"}},
+                    },
+                    {"metric_desc": {"id": "six-metric", "names": {"john": "maybe"}}},
+                ],
+                (4, ["p1", "p2"], {"john": ["maybe", "sure", "yes"]}),
+            ),
+        ),
+    )
+    async def test_metric_ids_unproc(self, fake_crucible, found, message):
+        """Test matching metric IDs with lax criteria"""
+
+        fake_crucible.elastic.set_query("metric_desc", found)
+        with pytest.raises(HTTPException) as exc:
+            await fake_crucible._get_metric_ids(
+                "runid",
+                "source::type",
+                aggregate=False,
+            )
+        assert 422 == exc.value.status_code
+        assert {
+            "message": f"More than one metric ({message[0]}) means you should add breakout filters or aggregate.",
+            "periods": message[1],
+            "names": message[2],
+        } == exc.value.detail
 
     async def test_run_filters(self, fake_crucible):
         """Test aggregations
@@ -176,7 +672,7 @@ class TestCrucible:
 
         fake_crucible.elastic.set_query(
             "tag",
-            aggregation_list={
+            aggregations={
                 "key": [
                     {
                         "key": "topology",
@@ -216,7 +712,7 @@ class TestCrucible:
         )
         fake_crucible.elastic.set_query(
             "param",
-            aggregation_list={
+            aggregations={
                 "key": [
                     {
                         "key": "bucket",
@@ -232,7 +728,7 @@ class TestCrucible:
         )
         fake_crucible.elastic.set_query(
             "run",
-            aggregation_list={
+            aggregations={
                 "begin": [{"key": 123456789, "doc_count": 1}],
                 "benchmark": [{"key": "ilab", "doc_count": 25}],
                 "desc": [],
@@ -263,3 +759,1332 @@ class TestCrucible:
         assert sorted(filters["run"]["benchmark"]) == ["ilab"]
         assert sorted(filters["run"]["email"]) == ["me@example.com", "you@example.com"]
         assert sorted(filters["run"]["host"]) == ["one.example.com", "two.example.com"]
+
+    async def test_get_run_ids(self, fake_crucible: CrucibleService):
+        """_get_run_ids
+
+        This is just straightline code coverage as there's no point in mocking
+        the filters.
+        """
+        fake_crucible.elastic.set_query(
+            "period",
+            [{"run": {"id": "one"}}, {"run": {"id": "two"}}, {"run": {"id": "three"}}],
+        )
+        assert {"one", "two", "three"} == await fake_crucible._get_run_ids(
+            "period", [{"term": {"period.name": "measurement"}}]
+        )
+
+    async def test_get_runs_none(self, fake_crucible: CrucibleService):
+        """Test run summary"""
+        fake_crucible.elastic.set_query("run", [])
+        fake_crucible.elastic.set_query("iteration", [])
+        fake_crucible.elastic.set_query("tag", [])
+        fake_crucible.elastic.set_query("param", [])
+        assert {
+            "count": 0,
+            "offset": 0,
+            "results": [],
+            "sort": [],
+            "total": 0,
+        } == await fake_crucible.get_runs()
+
+    async def test_get_runs_time_reverse(self, fake_crucible: CrucibleService):
+        """Test run summary"""
+        fake_crucible.elastic.set_query("run", [])
+        fake_crucible.elastic.set_query("iteration", [])
+        fake_crucible.elastic.set_query("tag", [])
+        fake_crucible.elastic.set_query("param", [])
+        with pytest.raises(HTTPException) as exc:
+            await fake_crucible.get_runs(start="2025-01-01", end="2024-01-01")
+        assert 422 == exc.value.status_code
+        assert {
+            "error": "Invalid date format, start_date must be less than end_date"
+        } == exc.value.detail
+
+    @pytest.mark.parametrize(
+        "args,miss,notag,noparam",
+        (
+            ({}, False, False, False),
+            ({"size": 2, "offset": 1}, False, False, False),
+            ({"start": "2024-01-01"}, False, False, False),
+            ({"end": "2024-02-01"}, False, False, False),
+            ({"start": "2024-01-01", "end": "2025-01-01"}, False, False, False),
+            ({"sort": ["end:desc"]}, False, False, False),
+            (
+                {"filter": ["tag:a=42", "param:z=xyzzy", "run:benchmark=test"]},
+                False,
+                False,
+                False,
+            ),
+            ({"filter": ["tag:a=42", "param:z=xyzzy"]}, True, False, False),
+            ({"filter": ["tag:a=42", "param:z=xyzzy"]}, False, True, False),
+            ({"filter": ["tag:a=42", "param:z=xyzzy"]}, False, False, True),
+        ),
+    )
+    async def test_get_runs_queries(
+        self, args, miss, notag, noparam, fake_crucible: CrucibleService
+    ):
+        """Test processing of various query parameters
+
+        Note, this isn't really testing "behavior" of the filters, which is all
+        in Opensearch, just the CPT service's handling of the query parameters.
+
+        TBD: This should really verify the generated Opensearch query filters,
+        although that's mostly covered by earlier tests.
+        """
+        runs = [
+            {"run": {"id": "r1", "begin": "0", "end": "5000", "benchmark": "test"}},
+        ]
+        if miss:
+            # Add additional runs which will be rejected by filters
+            runs.extend(
+                [
+                    {
+                        "run": {
+                            "id": "r2",
+                            "begin": "110",
+                            "end": "7000",
+                            "benchmark": "test",
+                        }
+                    },
+                    {
+                        "run": {
+                            "id": "r3",
+                            "begin": "110",
+                            "end": "6000",
+                            "benchmark": "test",
+                        }
+                    },
+                ]
+            )
+        fake_crucible.elastic.set_query("run", runs)
+        fake_crucible.elastic.set_query(
+            "iteration",
+            [
+                {
+                    "run": {"id": "r1"},
+                    "iteration": {
+                        "id": "i1",
+                        "num": 1,
+                        "primary-period": "tp",
+                        "primary-metric": "src::tst1",
+                        "status": "pass",
+                    },
+                },
+                {
+                    "run": {"id": "r1"},
+                    "iteration": {
+                        "id": "i2",
+                        "num": 2,
+                        "primary-period": "tp",
+                        "primary-metric": "src::tst2",
+                        "status": "pass",
+                    },
+                },
+                {
+                    "run": {"id": "r1"},
+                    "iteration": {
+                        "id": "i3",
+                        "num": 3,
+                        "primary-period": "tp",
+                        "primary-metric": "src::tst1",
+                        "status": "fail",
+                    },
+                },
+            ],
+        )
+
+        if notag:
+            tags = []
+        else:
+            tags = [
+                {"run": {"id": "r1"}, "tag": {"name": "a", "val": 42}},
+                {"run": {"id": "r2"}, "tag": {"name": "a", "val": 42}},
+            ]
+        fake_crucible.elastic.set_query("tag", tags, repeat=2)
+
+        if noparam:
+            params = []
+        else:
+            params = [
+                {
+                    "run": {"id": "r1"},
+                    "iteration": {"id": "i1"},
+                    "param": {"arg": "b", "val": "cde"},
+                },
+                {
+                    "run": {"id": "r1"},
+                    "iteration": {"id": "i1"},
+                    "param": {"arg": "z", "val": "xyzzy"},
+                },
+                {
+                    "run": {"id": "r3"},
+                    "iteration": {"id": "i1"},
+                    "param": {"arg": "z", "val": "xyzzy"},
+                },
+                {
+                    "run": {"id": "r1"},
+                    "iteration": {"id": "i2"},
+                    "param": {"arg": "b", "val": "cde"},
+                },
+                {
+                    "run": {"id": "r1"},
+                    "iteration": {"id": "i2"},
+                    "param": {"arg": "x", "val": "plugh"},
+                },
+            ]
+        fake_crucible.elastic.set_query("param", params, repeat=2)
+        expected = {
+            "count": 1,
+            "offset": 0,
+            "results": [
+                {
+                    "begin": "0",
+                    "begin_date": "1970-01-01 00:00:00+00:00",
+                    "benchmark": "test",
+                    "end": "5000",
+                    "end_date": "1970-01-01 00:00:05+00:00",
+                    "id": "r1",
+                    "iterations": [
+                        {
+                            "iteration": 1,
+                            "params": defaultdict(
+                                None,
+                                {
+                                    "b": "cde",
+                                    "z": "xyzzy",
+                                },
+                            ),
+                            "primary_metric": "src::tst1",
+                            "primary_period": "tp",
+                            "status": "pass",
+                        },
+                        {
+                            "iteration": 2,
+                            "params": defaultdict(
+                                None,
+                                {
+                                    "b": "cde",
+                                    "x": "plugh",
+                                },
+                            ),
+                            "primary_metric": "src::tst2",
+                            "primary_period": "tp",
+                            "status": "pass",
+                        },
+                        {
+                            "iteration": 3,
+                            "params": {},
+                            "primary_metric": "src::tst1",
+                            "primary_period": "tp",
+                            "status": "fail",
+                        },
+                    ],
+                    "params": {},
+                    "primary_metrics": {"src::tst1", "src::tst2"},
+                    "status": "fail",
+                    "tags": defaultdict(None, {"a": 42}),
+                },
+            ],
+            "sort": [],
+            "total": 1,
+        }
+        if notag or noparam:
+            expected["results"] = []
+            expected["count"] = 0
+            expected["total"] = 0
+        else:
+            if miss:
+                expected["total"] = 3
+        if "size" in args:
+            expected["size"] = args["size"]
+        if args.get("offset"):
+            expected["offset"] = args["offset"]
+        if args.get("start"):
+            expected["startDate"] = (
+                datetime.fromisoformat(args["start"])
+                .astimezone(tz=timezone.utc)
+                .isoformat()
+            )
+        if args.get("end"):
+            expected["endDate"] = (
+                datetime.fromisoformat(args["end"])
+                .astimezone(tz=timezone.utc)
+                .isoformat()
+            )
+        if args.get("sort"):
+            expected["sort"] = args["sort"]
+        assert expected == await fake_crucible.get_runs(**args)
+
+    async def test_get_tags(self, fake_crucible: CrucibleService):
+        """Get tags for a run ID"""
+        fake_crucible.elastic.set_query(
+            "tag",
+            [
+                {"run": {"id": "one"}, "tag": {"name": "a", "val": 123}},
+                {"run": {"id": "one"}, "tag": {"name": "b", "val": "hello"}},
+                {"run": {"id": "one"}, "tag": {"name": "c", "val": False}},
+            ],
+        )
+        assert {"a": 123, "b": "hello", "c": False} == await fake_crucible.get_tags(
+            "one"
+        )
+
+    async def test_get_params_none(self, fake_crucible: CrucibleService):
+        """Test error when neither run nor iteration is specified"""
+        with pytest.raises(HTTPException) as exc:
+            await fake_crucible.get_params()
+        assert 400 == exc.value.status_code
+        assert (
+            "A params query requires either a run or iteration ID" == exc.value.detail
+        )
+
+    async def test_get_params_run(self, fake_crucible: CrucibleService):
+        """Get parameters for a run"""
+        params = [
+            {
+                "run": {"id": "rid"},
+                "iteration": {"id": "iid1"},
+                "param": {"arg": "a", "val": 10},
+            },
+            {
+                "run": {"id": "rid"},
+                "iteration": {"id": "iid1"},
+                "param": {"arg": "b", "val": 5},
+            },
+            {
+                "run": {"id": "rid"},
+                "iteration": {"id": "iid1"},
+                "param": {"arg": "c", "val": "val"},
+            },
+            {
+                "run": {"id": "rid"},
+                "iteration": {"id": "iid2"},
+                "param": {"arg": "a", "val": 7},
+            },
+            {
+                "run": {"id": "rid"},
+                "iteration": {"id": "iid2"},
+                "param": {"arg": "c", "val": "val"},
+            },
+        ]
+        fake_crucible.elastic.set_query("param", params)
+        assert {
+            "common": {"c": "val"},
+            "iid1": {"a": 10, "b": 5, "c": "val"},
+            "iid2": {"a": 7, "c": "val"},
+        } == await fake_crucible.get_params("rid")
+
+    async def test_get_params_iteration(self, fake_crucible: CrucibleService):
+        """Get parameters for an iteration"""
+        params = [
+            {
+                "run": {"id": "rid"},
+                "iteration": {"id": "iid1"},
+                "param": {"arg": "a", "val": 10},
+            },
+            {
+                "run": {"id": "rid"},
+                "iteration": {"id": "iid1"},
+                "param": {"arg": "b", "val": 5},
+            },
+            {
+                "run": {"id": "rid"},
+                "iteration": {"id": "iid1"},
+                "param": {"arg": "c", "val": "val"},
+            },
+        ]
+        fake_crucible.elastic.set_query("param", params)
+        assert {
+            "iid1": {"a": 10, "b": 5, "c": "val"}
+        } == await fake_crucible.get_params(None, "iid1")
+
+    async def test_get_params_iteration_dup(self, fake_crucible: CrucibleService):
+        """Cover an obscure log warning case"""
+        params = [
+            {
+                "run": {"id": "rid"},
+                "iteration": {"id": "iid1"},
+                "param": {"arg": "a", "val": 10},
+            },
+            {
+                "run": {"id": "rid"},
+                "iteration": {"id": "iid1"},
+                "param": {"arg": "a", "val": 5},
+            },
+        ]
+        fake_crucible.elastic.set_query("param", params)
+        assert {"iid1": {"a": 5}} == await fake_crucible.get_params(None, "iid1")
+
+    async def test_get_iterations(self, fake_crucible: CrucibleService):
+        """Get iterations for a run ID"""
+        iterations = [
+            {
+                "id": "one",
+                "num": 1,
+                "path": None,
+                "primary_metric": "test::metric1",
+                "primary_period": "measurement",
+                "status": "pass",
+            },
+            {
+                "id": "two",
+                "num": 2,
+                "path": None,
+                "primary_metric": "test::metric2",
+                "primary_period": "measurement",
+                "status": "pass",
+            },
+            {
+                "id": "three",
+                "num": 3,
+                "path": None,
+                "primary_metric": "test::metric1",
+                "primary_period": "measurement",
+                "status": "pass",
+            },
+        ]
+        fake_crucible.elastic.set_query(
+            "iteration",
+            [
+                {
+                    "run": {"id": "one"},
+                    "iteration": i,
+                }
+                for i in iterations
+            ],
+        )
+        assert iterations == await fake_crucible.get_iterations("one")
+
+    async def test_get_samples_none(self, fake_crucible: CrucibleService):
+        """Test error when neither run nor iteration is specified"""
+        with pytest.raises(HTTPException) as exc:
+            await fake_crucible.get_samples()
+        assert 400 == exc.value.status_code
+        assert (
+            "A sample query requires either a run or iteration ID" == exc.value.detail
+        )
+
+    @pytest.mark.parametrize("ids", (("one", None), (None, 1)))
+    async def test_get_samples(self, fake_crucible: CrucibleService, ids):
+        """Get samples for a run ID"""
+        samples = [
+            {
+                "num": "1",
+                "path": None,
+                "id": "one",
+                "status": "pass",
+                "primary_metric": "pm",
+                "primary_period": "m",
+                "iteration": 1,
+            },
+            {
+                "id": "two",
+                "num": "2",
+                "path": None,
+                "status": "pass",
+                "primary_metric": "pm",
+                "primary_period": "m",
+                "iteration": 1,
+            },
+            {
+                "id": "three",
+                "num": "3",
+                "path": None,
+                "status": "pass",
+                "primary_metric": "pm",
+                "primary_period": "m",
+                "iteration": 1,
+            },
+        ]
+        fake_crucible.elastic.set_query(
+            "sample",
+            [
+                {
+                    "run": {"id": "one"},
+                    "iteration": {
+                        "primary-metric": "pm",
+                        "primary-period": "m",
+                        "num": 1,
+                    },
+                    "sample": s,
+                }
+                for s in samples
+            ],
+        )
+        assert samples == await fake_crucible.get_samples(*ids)
+
+    async def test_get_periods_none(self, fake_crucible: CrucibleService):
+        """Test error when neither run, iteration, nor sample is specified"""
+        with pytest.raises(HTTPException) as exc:
+            await fake_crucible.get_periods()
+        assert 400 == exc.value.status_code
+        assert (
+            "A period query requires a run, iteration, or sample ID" == exc.value.detail
+        )
+
+    @pytest.mark.parametrize(
+        "ids", (("one", None, None), (None, 1, None), (None, None, 1))
+    )
+    async def test_get_periods(self, fake_crucible: CrucibleService, ids):
+        """Get samples for a run ID"""
+        periods = [
+            {
+                "begin": "2024-12-05 21:16:31.046000+00:00",
+                "end": "2024-12-05 21:40:31.166000+00:00",
+                "id": "306C8A78-B352-11EF-8E37-AD212D0A0B9F",
+                "name": "measurement",
+                "iteration": 1,
+                "sample": 1,
+                "primary_metric": "ilab::sdg-samples-sec",
+                "status": "pass",
+            }
+        ]
+        fake_crucible.elastic.set_query(
+            "period",
+            [
+                {
+                    "run": {"id": "one"},
+                    "iteration": {
+                        "primary-metric": p["primary_metric"],
+                        "primary-period": "measurement",
+                        "num": 1,
+                        "status": p["status"],
+                    },
+                    "sample": {"num": 1, "status": p["status"], "path": None},
+                    "period": {
+                        "id": p["id"],
+                        "name": p["name"],
+                        "begin": str(
+                            int(datetime.fromisoformat(p["begin"]).timestamp() * 1000)
+                        ),
+                        "end": str(
+                            int(datetime.fromisoformat(p["end"]).timestamp() * 1000)
+                        ),
+                        "primary-metric": p["primary_metric"],
+                        "status": p["status"],
+                    },
+                }
+                for p in periods
+            ],
+        )
+        assert periods == await fake_crucible.get_periods(*ids)
+
+    async def test_get_metrics_list(self, fake_crucible: CrucibleService):
+        """Get samples for a run ID"""
+        metrics = {
+            "source1::type1": {
+                "periods": [],
+                "breakouts": {"name1": ["value1", "value2"]},
+            },
+            "source1::type2": {"periods": ["p1", "p2"], "breakouts": {}},
+        }
+        query = [
+            {
+                "run": {"id": "one"},
+                "metric_desc": {
+                    "source": "source1",
+                    "type": "type1",
+                    "names": {"name1": "value1"},
+                },
+            },
+            {
+                "run": {"id": "one"},
+                "metric_desc": {
+                    "source": "source1",
+                    "type": "type1",
+                    "names": {"name1": "value1"},
+                },
+            },
+            {
+                "run": {"id": "one"},
+                "metric_desc": {
+                    "source": "source1",
+                    "type": "type1",
+                    "names": {"name1": "value2"},
+                },
+            },
+            {
+                "run": {"id": "one"},
+                "metric_desc": {
+                    "source": "source1",
+                    "type": "type1",
+                    "names": {"name1": "value2"},
+                },
+            },
+            {
+                "run": {"id": "one"},
+                "period": {"id": "p1"},
+                "metric_desc": {"source": "source1", "type": "type2", "names": {}},
+            },
+            {
+                "run": {"id": "one"},
+                "period": {"id": "p2"},
+                "metric_desc": {"source": "source1", "type": "type2", "names": {}},
+            },
+        ]
+        fake_crucible.elastic.set_query("metric_desc", query)
+        result = await fake_crucible.get_metrics_list("one")
+
+        # NOTE: the method returns a defaultdict, which doesn't compare to a
+        # dict but "in the real world" serializes the same: so we just
+        # serialize and deserialize to mimic the actual API behavior.
+        result = json.loads(json.dumps(result))
+        assert metrics == result
+
+    async def test_get_metric_breakout_none(self, fake_crucible: CrucibleService):
+        """Test error when the metric isn't found"""
+        fake_crucible.elastic.set_query("metric_desc", [])
+        with pytest.raises(HTTPException) as exc:
+            await fake_crucible.get_metric_breakouts(
+                "one", metric="source1::type1", names=[], periods=[]
+            )
+        assert 400 == exc.value.status_code
+        assert "Metric name source1::type1 not found for run one" == exc.value.detail
+
+    @pytest.mark.parametrize("period", (True, False))
+    async def test_get_metric_breakout(self, period, fake_crucible: CrucibleService):
+        """Get samples for a run ID"""
+        metrics = {
+            "label": "source1::type1",
+            "class": ["classless", "classy"],
+            "type": "type1",
+            "source": "source1",
+            "breakouts": {"name1": ["value1", "value2"]},
+        }
+        md1 = {
+            "run": {"id": "one"},
+            "metric_desc": {
+                "source": "source1",
+                "type": "type1",
+                "class": "classy",
+                "names": {"name1": "value1"},
+            },
+        }
+        md2 = {
+            "run": {"id": "one"},
+            "metric_desc": {
+                "source": "source1",
+                "type": "type1",
+                "names": {"name1": "value2"},
+            },
+        }
+        if period:
+            metrics["periods"] = ["p1", "p2"]
+            md1["period"] = {"id": "p1"}
+            md2["period"] = {"id": "p2"}
+        query = [
+            md1,
+            md2,
+            {
+                "run": {"id": "one"},
+                "metric_desc": {
+                    "source": "source1",
+                    "type": "type1",
+                    "class": "classless",
+                    "names": {"name1": "value1"},
+                },
+            },
+            {
+                "run": {"id": "one"},
+                "metric_desc": {
+                    "source": "source1",
+                    "type": "type1",
+                    "names": {"name1": "value2"},
+                },
+            },
+        ]
+        fake_crucible.elastic.set_query("metric_desc", query)
+        result = await fake_crucible.get_metric_breakouts(
+            "one", metric="source1::type1", names=[], periods=[]
+        )
+
+        # NOTE: the method returns a defaultdict, which doesn't compare to a
+        # dict but "in the real world" serializes the same: so we just
+        # serialize and deserialize to mimic the actual API behavior.
+        result = json.loads(json.dumps(result))
+        assert metrics == result
+
+    async def test_metrics_data_one_noagg(self, fake_crucible: CrucibleService):
+        """Return data samples for a single metric"""
+
+        fake_crucible.elastic.set_query(
+            "metric_desc",
+            [{"metric_desc": {"id": "one-metric", "names": {}}}],
+        )
+        fake_crucible.elastic.set_query(
+            "metric_data",
+            [
+                {
+                    "metric_desc": {"id": "one-metric"},
+                    "metric_data": {
+                        "begin": "1726165775123",
+                        "end": "1726165789213",
+                        "duration": 14100,
+                        "value": 9.35271216694379,
+                    },
+                },
+                {
+                    "metric_desc": {"id": "one-metric"},
+                    "metric_data": {
+                        "begin": "1726165790000",
+                        "end": "1726165804022",
+                        "duration": 14022,
+                        "value": 9.405932330557683,
+                    },
+                },
+            ],
+        )
+        expected = [
+            {
+                "begin": "2024-09-12 18:29:35.123000+00:00",
+                "duration": 14.1,
+                "end": "2024-09-12 18:29:49.213000+00:00",
+                "value": 9.35271216694379,
+            },
+            {
+                "begin": "2024-09-12 18:29:50+00:00",
+                "duration": 14.022,
+                "end": "2024-09-12 18:30:04.022000+00:00",
+                "value": 9.405932330557683,
+            },
+        ]
+        assert expected == await fake_crucible.get_metrics_data("runid", "source::type")
+        assert fake_crucible.elastic.requests == [
+            Request(
+                "cdmv7dev-metric_desc",
+                {
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "run.id": "runid",
+                                    },
+                                },
+                                {
+                                    "term": {
+                                        "metric_desc.source": "source",
+                                    },
+                                },
+                                {
+                                    "term": {
+                                        "metric_desc.type": "type",
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    "size": 262144,
+                },
+                kwargs={"ignore_unavailable": True},
+            ),
+            Request(
+                "cdmv7dev-metric_data",
+                {
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "terms": {
+                                        "metric_desc.id": [
+                                            "one-metric",
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    "size": 262144,
+                },
+            ),
+        ]
+
+    @pytest.mark.parametrize("count", (0, 2))
+    async def test_metrics_data_agg(self, count, fake_crucible):
+        """Return data samples for aggregated metrics"""
+
+        fake_crucible.elastic.set_query(
+            "metric_desc",
+            [
+                {"metric_desc": {"id": "one-metric", "names": {}}},
+                {"metric_desc": {"id": "two-metric", "names": {}}},
+            ],
+        )
+        fake_crucible.elastic.set_query(
+            "metric_data",
+            aggregations={
+                "duration": {
+                    "count": count,
+                    "min": 14022,
+                    "max": 14100,
+                    "avg": 14061,
+                    "sum": 28122,
+                }
+            },
+        )
+        if count:
+            fake_crucible.elastic.set_query(
+                "metric_data",
+                aggregations={
+                    "interval": [
+                        {"key": 1726165789213, "value": {"value": 9.35271216694379}},
+                        {"key": 1726165804022, "value": {"value": 9.405932330557683}},
+                    ]
+                },
+            )
+            expected = [
+                {
+                    "begin": "2024-09-12 18:29:35.191000+00:00",
+                    "duration": 14.022,
+                    "end": "2024-09-12 18:29:49.213000+00:00",
+                    "value": 9.35271216694379,
+                },
+                {
+                    "begin": "2024-09-12 18:29:50+00:00",
+                    "duration": 14.022,
+                    "end": "2024-09-12 18:30:04.022000+00:00",
+                    "value": 9.405932330557683,
+                },
+            ]
+        else:
+            expected = []
+        assert expected == await fake_crucible.get_metrics_data(
+            "r1", "source::type", aggregate=True
+        )
+        expected_requests = [
+            Request(
+                "cdmv7dev-metric_desc",
+                {
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "run.id": "r1",
+                                    },
+                                },
+                                {
+                                    "term": {
+                                        "metric_desc.source": "source",
+                                    },
+                                },
+                                {
+                                    "term": {
+                                        "metric_desc.type": "type",
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    "size": 262144,
+                },
+                kwargs={"ignore_unavailable": True},
+            ),
+            Request(
+                "cdmv7dev-metric_data",
+                {
+                    "aggs": {
+                        "duration": {
+                            "stats": {
+                                "field": "metric_data.duration",
+                            },
+                        },
+                    },
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "terms": {
+                                        "metric_desc.id": [
+                                            "one-metric",
+                                            "two-metric",
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    "size": 0,
+                },
+            ),
+        ]
+        if count:
+            expected_requests.append(
+                Request(
+                    "cdmv7dev-metric_data",
+                    {
+                        "aggs": {
+                            "interval": {
+                                "aggs": {
+                                    "value": {
+                                        "sum": {
+                                            "field": "metric_data.value",
+                                        },
+                                    },
+                                },
+                                "histogram": {
+                                    "field": "metric_data.end",
+                                    "interval": 14022,
+                                },
+                            },
+                        },
+                        "query": {
+                            "bool": {
+                                "filter": [
+                                    {
+                                        "terms": {
+                                            "metric_desc.id": [
+                                                "one-metric",
+                                                "two-metric",
+                                            ],
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                        "size": 0,
+                    },
+                ),
+            )
+        assert fake_crucible.elastic.requests == expected_requests
+
+    async def test_metrics_summary(self, fake_crucible: CrucibleService):
+        """Return data summary for a metrics"""
+
+        fake_crucible.elastic.set_query(
+            "metric_desc",
+            [
+                {"metric_desc": {"id": "one-metric", "names": {"a": "1"}}},
+            ],
+        )
+        expected = {
+            "count": 5,
+            "min": 9.35271216694379,
+            "max": 9.405932330557683,
+            "avg": 9.379322249,
+            "sum": 18.758644498,
+        }
+        fake_crucible.elastic.set_query("metric_data", aggregations={"score": expected})
+        assert expected == await fake_crucible.get_metrics_summary(
+            "runid", "one-metric::type", ["a=1"]
+        )
+        assert fake_crucible.elastic.requests == [
+            Request(
+                "cdmv7dev-metric_desc",
+                {
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "run.id": "runid",
+                                    },
+                                },
+                                {
+                                    "term": {
+                                        "metric_desc.source": "one-metric",
+                                    },
+                                },
+                                {
+                                    "term": {
+                                        "metric_desc.type": "type",
+                                    },
+                                },
+                                {"term": {"metric_desc.names.a": "1"}},
+                            ],
+                        },
+                    },
+                    "size": 262144,
+                },
+                kwargs={"ignore_unavailable": True},
+            ),
+            Request(
+                "cdmv7dev-metric_data",
+                {
+                    "aggs": {"score": {"stats": {"field": "metric_data.value"}}},
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "terms": {
+                                        "metric_desc.id": [
+                                            "one-metric",
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    "size": 0,
+                },
+            ),
+        ]
+
+    @pytest.mark.parametrize(
+        "runs,param_idx,periods,period_idx,title",
+        (
+            ([], 0, [], 0, "source::type"),
+            (["r2", "r1"], 0, [], 0, "source::type {run 2}"),
+            ([], 0, ["p1"], 0, "source::type (n=42)"),
+            ([], 1, ["p1"], 1, "source::type"),
+            ([], 1, ["p1"], 2, "source::type"),
+        ),
+    )
+    async def test_graph_title_no_query(
+        self,
+        runs,
+        param_idx,
+        periods,
+        period_idx,
+        title,
+        fake_crucible: CrucibleService,
+    ):
+        """Test generation of default metric titles"""
+
+        param_runs = [
+            {"r1": {"i1": {"n": "42"}, "i2": {"n": "31"}}},
+            {"r1": {"i1": {"n": "42"}, "i2": {"n": "42"}}},
+        ][param_idx]
+        period_runs = [
+            {"r1": {"i1": {"p1"}, "i2": {"p2"}}},
+            {"r1": {"i1": {"p1"}}},
+            {"r1": {"i1": {"p2"}}},
+        ][period_idx]
+        name = await fake_crucible._graph_title(
+            "r1",
+            runs,
+            Graph(metric="source::type", periods=periods),
+            param_runs,
+            period_runs,
+        )
+        assert name == title
+
+    async def test_graph_title_query(self, fake_crucible: CrucibleService):
+        """Test generation of default metric titles"""
+
+        param_runs = {}
+        period_runs = {}
+        fake_crucible.elastic.set_query(
+            "param",
+            [
+                {
+                    "run": {"id": "r1"},
+                    "iteration": {"id": "i1"},
+                    "param": {"arg": "a", "val": "1"},
+                },
+            ],
+        )
+        fake_crucible.elastic.set_query(
+            "period",
+            [
+                {
+                    "run": {"id": "r1"},
+                    "iteration": {"id": "i1"},
+                    "period": {"id": "p1"},
+                },
+            ],
+        )
+        name = await fake_crucible._graph_title(
+            "r1",
+            [],
+            Graph(metric="source::type"),
+            param_runs,
+            period_runs,
+        )
+        assert name == "source::type"
+        assert fake_crucible.elastic.requests == [
+            Request(
+                "cdmv7dev-param",
+                {
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "run.id": "r1",
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    "size": 262144,
+                },
+            ),
+            Request(
+                "cdmv7dev-period",
+                {
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "run.id": "r1",
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    "size": 262144,
+                },
+            ),
+        ]
+
+    async def test_metrics_graph_norun(self, fake_crucible: CrucibleService):
+        with pytest.raises(HTTPException) as exc:
+            await fake_crucible.get_metrics_graph(
+                GraphList(
+                    name="graph",
+                    graphs=[Graph(metric="source::type", aggregate=True, title="test")],
+                )
+            )
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "each graph request must have a run ID"
+
+    @pytest.mark.parametrize("count", (0, 2))
+    async def test_metrics_graph(self, count, fake_crucible: CrucibleService):
+        """Return graph for aggregated metrics"""
+
+        metrics = [{"metric_desc": {"id": "one-metric", "names": {}}}]
+        if count:
+            metrics.append({"metric_desc": {"id": "two-metric", "names": {}}})
+            fake_crucible.elastic.set_query(
+                "metric_data",
+                aggregations={
+                    "duration": {
+                        "count": count,
+                        "min": 14022,
+                        "max": 14100,
+                        "avg": 14061,
+                        "sum": 28122,
+                    }
+                },
+            )
+            fake_crucible.elastic.set_query(
+                "metric_data",
+                aggregations={
+                    "interval": [
+                        {"key": 1726165789213, "value": {"value": 9.35271216694379}},
+                        {"key": 1726165804022, "value": {"value": 9.405932330557683}},
+                    ]
+                },
+            )
+            expected = {
+                "data": [
+                    {
+                        "labels": {
+                            "x": "sample timestamp",
+                            "y": "samples / second",
+                        },
+                        "marker": {
+                            "color": "black",
+                        },
+                        "mode": "line",
+                        "name": "test",
+                        "type": "scatter",
+                        "x": [
+                            "2024-09-12 18:29:49.213000+00:00",
+                            "2024-09-12 18:30:03.234000+00:00",
+                            "2024-09-12 18:30:04.022000+00:00",
+                            "2024-09-12 18:30:18.043000+00:00",
+                        ],
+                        "y": [
+                            9.35271216694379,
+                            9.35271216694379,
+                            9.405932330557683,
+                            9.405932330557683,
+                        ],
+                        "yaxis": "y",
+                    },
+                ],
+                "layout": {
+                    "width": "1500",
+                    "yaxis": {
+                        "color": "black",
+                        "title": "source::type",
+                    },
+                },
+            }
+        else:
+            expected = {
+                "data": [
+                    {
+                        "labels": {
+                            "x": "sample timestamp",
+                            "y": "samples / second",
+                        },
+                        "marker": {
+                            "color": "black",
+                        },
+                        "mode": "line",
+                        "name": "test",
+                        "type": "scatter",
+                        "x": [
+                            "2024-09-12 18:29:49.213000+00:00",
+                            "2024-09-12 18:29:50.213000+00:00",
+                            "2024-09-12 18:30:04.022000+00:00",
+                            "2024-09-12 18:30:05.022000+00:00",
+                        ],
+                        "y": [
+                            9.35271216694379,
+                            9.35271216694379,
+                            9.405932330557683,
+                            9.405932330557683,
+                        ],
+                        "yaxis": "y",
+                    },
+                ],
+                "layout": {
+                    "width": "1500",
+                    "yaxis": {
+                        "color": "black",
+                        "title": "source::type",
+                    },
+                },
+            }
+            fake_crucible.elastic.set_query(
+                "metric_data",
+                [
+                    {
+                        "metric_data": {
+                            "begin": "1726165789213",
+                            "end": "1726165790213",
+                            "value": 9.35271216694379,
+                        }
+                    },
+                    {
+                        "metric_data": {
+                            "begin": "1726165804022",
+                            "end": "1726165805022",
+                            "value": 9.405932330557683,
+                        }
+                    },
+                ],
+            )
+        fake_crucible.elastic.set_query("metric_desc", metrics)
+
+        assert expected == await fake_crucible.get_metrics_graph(
+            GraphList(
+                run="r1",
+                name="graph",
+                graphs=[Graph(metric="source::type", aggregate=True, title="test")],
+            )
+        )
+        expected_requests = [
+            Request(
+                "cdmv7dev-metric_desc",
+                {
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "run.id": "r1",
+                                    },
+                                },
+                                {
+                                    "term": {
+                                        "metric_desc.source": "source",
+                                    },
+                                },
+                                {
+                                    "term": {
+                                        "metric_desc.type": "type",
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    "size": 262144,
+                },
+                kwargs={"ignore_unavailable": True},
+            ),
+        ]
+        if count:
+            expected_requests.extend(
+                [
+                    Request(
+                        "cdmv7dev-metric_data",
+                        {
+                            "aggs": {
+                                "duration": {
+                                    "stats": {
+                                        "field": "metric_data.duration",
+                                    },
+                                },
+                            },
+                            "query": {
+                                "bool": {
+                                    "filter": [
+                                        {
+                                            "terms": {
+                                                "metric_desc.id": [
+                                                    "one-metric",
+                                                    "two-metric",
+                                                ],
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                            "size": 0,
+                        },
+                    ),
+                    Request(
+                        "cdmv7dev-metric_data",
+                        {
+                            "aggs": {
+                                "interval": {
+                                    "aggs": {
+                                        "value": {
+                                            "sum": {
+                                                "field": "metric_data.value",
+                                            },
+                                        },
+                                    },
+                                    "histogram": {
+                                        "field": "metric_data.begin",
+                                        "interval": 14022,
+                                    },
+                                },
+                            },
+                            "query": {
+                                "bool": {
+                                    "filter": [
+                                        {
+                                            "terms": {
+                                                "metric_desc.id": [
+                                                    "one-metric",
+                                                    "two-metric",
+                                                ],
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                            "size": 0,
+                        },
+                    ),
+                ]
+            )
+        else:
+            expected_requests.append(
+                Request(
+                    "cdmv7dev-metric_data",
+                    {
+                        "query": {
+                            "bool": {
+                                "filter": [
+                                    {
+                                        "terms": {
+                                            "metric_desc.id": ["one-metric"],
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                        "size": 262144,
+                    },
+                ),
+            )
+        assert fake_crucible.elastic.requests == expected_requests


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This brings unit test coverage of the Crucible service up to 96%. That seems more than adequate at this point, given that subsequent ILAB PRs rework some of the API code and it'll require adjustments anyway.

This is chained from #122 (Crucible service) -> #140 (unit test framework) -> #146 (crucible unit tests)

## Related Tickets & Documents

[PANDA-678](https://issues.redhat.com/browse/PANDA-678) crucible service unit test coverage

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

`tox -e unit -- -vv` (the `-- -vv` adds full diffs on failure for test debugging, and is optional)

Coverage is reported inline in text summary form, and also generates a detailed HTML report in the local `/var/tmp/${USER}/html/` which can be viewed in the browser to find holes.