### PR TITLE
Bug Fix Empty Job Data

### DIFF
--- a/backend/app/api/v1/endpoints/ocp/graph.py
+++ b/backend/app/api/v1/endpoints/ocp/graph.py
@@ -204,8 +204,9 @@ async def graph(uuid: str):
     return metrics
 
 async def jobSummary(uuids: list):
-    # if not uuids:
-    #     return []
+    # do not want every job summary
+    if not uuids:
+        return []
     index = "ripsaw-kube-burner*"
     ids = "\" OR uuid: \"".join(uuids)
     query = {

--- a/backend/app/api/v1/endpoints/ocp/graph.py
+++ b/backend/app/api/v1/endpoints/ocp/graph.py
@@ -204,9 +204,6 @@ async def graph(uuid: str):
     return metrics
 
 async def jobSummary(uuids: list):
-    # do not want every job summary
-    if not uuids:
-        return []
     index = "ripsaw-kube-burner*"
     ids = "\" OR uuid: \"".join(uuids)
     query = {

--- a/backend/app/api/v1/endpoints/ocp/graph.py
+++ b/backend/app/api/v1/endpoints/ocp/graph.py
@@ -204,6 +204,8 @@ async def graph(uuid: str):
     return metrics
 
 async def jobSummary(uuids: list):
+    # if not uuids:
+    #     return []
     index = "ripsaw-kube-burner*"
     ids = "\" OR uuid: \"".join(uuids)
     query = {
@@ -238,6 +240,9 @@ async def processNetperf(data: dict) :
     return tput
 
 def jobFilter(pdata: dict, data: dict):
+    # need at least one record to avoid out of bounds error
+    if not pdata:
+        return []
     columns = ['uuid','jobConfig.jobIterations']
     pdf = pd.json_normalize(pdata)
     pick_df = pd.DataFrame(pdf, columns=columns)


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #164 

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.

I deployed the changes locally with the application configured to ingest from the PerfScale internal databases.

- Please provide detailed steps to perform tests related to this code change.

A `virt-density` job summary query with a UUID on the `ripsaw-kube-burner*` index returned an empty response (i.e. no job summary data in the `dict`).

- How were the fix/results from this change verified? Please provide relevant screenshots or results.

No index out of bounds exception was thrown in the logs of backend data service.
