### PR TITLE
Workaround poetry and pip hashed requirements bug

### DIFF
--- a/backend/backend.containerfile
+++ b/backend/backend.containerfile
@@ -19,7 +19,7 @@ RUN dnf install -y pip gcc python3-devel gcc-c++
 
 RUN pip install --user poetry && \
     poetry self add poetry-plugin-export && \
-    poetry export -f requirements.txt -o requirements.txt && \
+    poetry export --without-hashes -f requirements.txt -o requirements.txt && \
     pip install -U typing-extensions && \
     pip install --user dash && \
     pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When building the python data service backend image for the cpt dashboard with additional software development dependencies with extra dependencies, like [coverage[toml]](https://github.com/nedbat/coveragepy),  the following error occurs. I believe this is related [PIP 9644 --require-hashes does not correctly handle pinned package with extras](https://github.com/pypa/pip/issues/9644).

```shell
$ podman build -f backend/backend.containerfile --tag backend
...
Collecting coverage[toml]>=7.5
ERROR: In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
    coverage[toml]>=7.5 from https://files.pythonhosted.org/packages/e0/10/a3d317e38e5627b06debe861d6c511b1611dd9dc0e2a47afbe6257ffd341/coverage-7.6.12-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=1a936309a65cc5ca80fa9f20a442ff9e2d06927ec9a4f54bcba9c14c066323f2 
(from pytest-cov==6.0.0->-r requirements.txt (line 981))
Error: building at STEP "RUN pip install --user poetry &&     
  poetry self add poetry-plugin-export &&     
  poetry export -f requirements.txt -o requirements.txt &&     
  pip install -U typing-extensions &&     
  pip install --user dash &&     
  pip install --no-cache-dir -r requirements.txt": while running runtime: exit status 1
```

<!--- Describe your changes in detail -->

## Related Tickets & Documents



- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
Locally, on my Fedora laptop machine.

- Please provide detailed steps to perform tests related to this code change.

```shell
$ poetry add coverage[toml]
$ podman build -f backend/backend.containerfile --tag backend
...
```

- How were the fix/results from this change verified? Please provide relevant screenshots or results.

```shell
$ podman build -f backend/backend.containerfile --tag backend
```
Builds without any errors from `pip`.
