### PR TITLE
add guard to check if element is in container

### DIFF
--- a/backend/app/api/v1/endpoints/ocp/graph.py
+++ b/backend/app/api/v1/endpoints/ocp/graph.py
@@ -328,7 +328,7 @@ async def getBurnerCPUResults(uuids: list, namespace: str, index: str ):
 
 async def getBurnerResults(uuid: str, uuids: list, index: str ):
     if len(uuids) > 1 :
-        if len(uuid) > 0 :
+        if len(uuid) > 0 and uuid in uuids:
             uuids.remove(uuid)
     if len(uuids) < 1 :
         return []


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

Occasionally, the cpt dashboard's python data service will raise a ValueError because it attempts to [remove a UUID not in its list of UUIDs in getResults()](https://github.com/cloud-bulldozer/cpt-dashboard/blob/b031df2befe096e852240fc22b50599784409fb9/backend/app/api/v1/endpoints/ocp/graph.py#L354).

## Description

Added a guard clause to check if the given UUID is in the container of UUIDs.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
Locally on my Fedora laptop connected to PerfScale data.

- Please provide detailed steps to perform tests related to this code change.

```shell
❯ ./local-compose
...
❯ podman logs --follow back
INFO:     Started server process [2]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
INFO:     127.0.0.1:46350 - "GET /api/v1/ocp/
...
```

Open a web browser to `localhost:3000`.

If the left sidebar is not open, click the hamburger (three stacked, horizontal lines) icon.

Select `OCP`.

From the filter drop down box, select `Status`.

Look for the `udn-density-pods` benchmark with Release Stream `4.18.0-0.nightly` executed on Feb 14, 2025, 12:32 AM. Click the embedded arrow to display the performance test's results.

You should see the GUI responding to some error, and no results for the performance test.

![Screenshot From 2025-02-18 11-21-32](https://github.com/user-attachments/assets/e585df4f-1909-46ec-90fd-945bc0dacf32)

The error as logged by the python data service backend.

```shell
...
graph/6b252c9d-3cd5-49a5-95b3-7144b241cc59 HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/anyio/streams/memory.py", line 98, in receive
    return self.receive_nowait()
  File "/usr/local/lib/python3.9/site-packages/anyio/streams/memory.py", line 93, in receive_nowait
    raise WouldBlock
anyio.WouldBlock

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/base.py", line 78, in call_next
    message = await recv_stream.receive()
  File "/usr/local/lib/python3.9/site-packages/anyio/streams/memory.py", line 118, in receive
    raise EndOfStream
anyio.EndOfStream

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/uvicorn/protocols/http/httptools_impl.py", line 371, in run_asgi
    result = await app(self.scope, self.receive, self.send)
  File "/usr/local/lib/python3.9/site-packages/uvicorn/middleware/proxy_headers.py", line 59, in __call__
    return await self.app(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/fastapi/applications.py", line 1106, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/applications.py", line 122, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/base.py", line 108, in __call__
    response = await self.dispatch_func(request, call_next)
  File "/backend/./app/main.py", line 54, in some_middleware
    return await call_next(request)
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/base.py", line 84, in call_next
    raise app_exc
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/base.py", line 70, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/cors.py", line 91, in __call__
    await self.simple_response(scope, receive, send, request_headers=headers)
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/cors.py", line 146, in simple_response
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/usr/local/lib/python3.9/site-packages/fastapi/middleware/asyncexitstack.py", line 20, in __call__
    raise e
  File "/usr/local/lib/python3.9/site-packages/fastapi/middleware/asyncexitstack.py", line 17, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 718, in __call__
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 66, in app
    response = await func(request)
  File "/usr/local/lib/python3.9/site-packages/fastapi/routing.py", line 274, in app
    raw_response = await run_endpoint_function(
  File "/usr/local/lib/python3.9/site-packages/fastapi/routing.py", line 191, in run_endpoint_function
    return await dependant.call(**values)
  File "/backend/./app/api/v1/endpoints/ocp/graph.py", line 171, in graph
    oData = await getBurnerResults(uuid,ids,index)
  File "/backend/./app/api/v1/endpoints/ocp/graph.py", line 332, in getBurnerResults
    uuids.remove(uuid)
ValueError: list.remove(x): x not in list
```

- How were the fix/results from this change verified? Please provide relevant screenshots or results.

No error was produced in the backend python data service, nor in the front GUI. The performance test's inputs and results are displayed.

```shell
❯ podman logs --follow back
INFO:     Started server process [2]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
...
query and response omitted because they are huge
...
[173 rows x 13 columns]
6b252c9d-3cd5-49a5-95b3-7144b241cc59
{'query': {'query_string': {'query': '( uuid: "6b252c9d-3cd5-49a5-95b3-7144b241cc59" ) AND metricName: "podLatencyQuantilesMeasurement" AND quantileName: "Ready"'}}}
[]
Empty DataFrame
Columns: []
Index: []
INFO:     127.0.0.1:34074 - "GET /api/v1/ocp/graph/6b252c9d-3cd5-49a5-95b3-7144b241cc59 HTTP/1.1" 200 OK
```

![Screenshot From 2025-02-18 11-27-28](https://github.com/user-attachments/assets/4bd0b32e-06c1-4f4c-8604-165b712a30d8)

