### PR TITLE
add call to drop na

### DIFF
--- a/backend/app/api/v1/endpoints/ocp/graph.py
+++ b/backend/app/api/v1/endpoints/ocp/graph.py
@@ -245,17 +245,12 @@ def jobFilter(pdata: dict, data: dict):
     pdf = pd.json_normalize(pdata)
     # for jsons without a jobConfig.jobIteration value, json_normalize() 
     # fills in Not a Number (NaN)
-    # pick_df = pd.DataFrame(pdf, columns=columns)
     pick_df = pd.DataFrame(pdf, columns=columns).dropna(subset=['jobConfig.jobIterations'])
-    print(f"jobFilter pick df {pick_df['jobConfig.jobIterations'].hasnans}")    
-    iterations = pick_df.iloc[0]['jobConfig.jobIterations']
     df = pd.json_normalize(data)
     # same as above
     ndf = pd.DataFrame(df, columns=columns).dropna(subset=['jobConfig.jobIterations'])
-    # ndf = pd.DataFrame(df, columns=columns)
-    print(f"jobFilter ndf {ndf['jobConfig.jobIterations'].hasnans}")
-    ids_df = ndf.loc[df['jobConfig.jobIterations'] == iterations ]
-    return ids_df['uuid'].to_list()
+    records_matched = ndf['jobConfig.jobIterations'].isin(pick_df['jobConfig.jobIterations'])
+    return ndf[ records_matched ]['uuid'].unique().tolist()
 
 def burnerFilter(data: dict) :
     #

--- a/backend/app/api/v1/endpoints/ocp/graph.py
+++ b/backend/app/api/v1/endpoints/ocp/graph.py
@@ -243,10 +243,13 @@ def jobFilter(pdata: dict, data: dict):
         return []
     columns = ['uuid','jobConfig.jobIterations']
     pdf = pd.json_normalize(pdata)
-    pick_df = pd.DataFrame(pdf, columns=columns)
+    # for jsons without a jobConfig.jobIteration value, json_normalize() 
+    # fills in Not a Number (NaN)
+    pick_df = pd.DataFrame(pdf, columns=columns).dropna(subset=['jobConfig.jobIterations'])
     iterations = pick_df.iloc[0]['jobConfig.jobIterations']
     df = pd.json_normalize(data)
-    ndf = pd.DataFrame(df, columns=columns)
+    # same as above
+    ndf = pd.DataFrame(df, columns=columns).dropna(subset=['jobConfig.jobIterations'])
     ids_df = ndf.loc[df['jobConfig.jobIterations'] == iterations ]
     return ids_df['uuid'].to_list()
 

--- a/backend/app/api/v1/endpoints/ocp/graph.py
+++ b/backend/app/api/v1/endpoints/ocp/graph.py
@@ -245,11 +245,15 @@ def jobFilter(pdata: dict, data: dict):
     pdf = pd.json_normalize(pdata)
     # for jsons without a jobConfig.jobIteration value, json_normalize() 
     # fills in Not a Number (NaN)
+    # pick_df = pd.DataFrame(pdf, columns=columns)
     pick_df = pd.DataFrame(pdf, columns=columns).dropna(subset=['jobConfig.jobIterations'])
+    print(f"jobFilter pick df {pick_df['jobConfig.jobIterations'].hasnans}")    
     iterations = pick_df.iloc[0]['jobConfig.jobIterations']
     df = pd.json_normalize(data)
     # same as above
     ndf = pd.DataFrame(df, columns=columns).dropna(subset=['jobConfig.jobIterations'])
+    # ndf = pd.DataFrame(df, columns=columns)
+    print(f"jobFilter ndf {ndf['jobConfig.jobIterations'].hasnans}")
     ids_df = ndf.loc[df['jobConfig.jobIterations'] == iterations ]
     return ids_df['uuid'].to_list()
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add two calls to `panda.drop_na()` to remove missing, Not a Number (NaN), values from the given job summary.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
Locally, on my Fedora Linux machine.

- Please provide detailed steps to perform tests related to this code change.
I added print statements to `jobFilter()` to show if the `jobConfig.jobIteration` column had any NaNs.

```python
def jobFilter(pdata: dict, data: dict):
    # need at least one record to avoid out of bounds error
    if not pdata or not data:
        return []
    columns = ['uuid','jobConfig.jobIterations']
    pdf = pd.json_normalize(pdata)
    # for jsons without a jobConfig.jobIteration value, json_normalize() 
    # fills in Not a Number (NaN)
    pick_df = pd.DataFrame(pdf, columns=columns)
    print(f"jobFilter pick df {pick_df['jobConfig.jobIterations'].hasnans}")
    # pick_df = pd.DataFrame(pdf, columns=columns).dropna(subset=['jobConfig.jobIterations'])
    iterations = pick_df.iloc[0]['jobConfig.jobIterations']
    df = pd.json_normalize(data)
    # same as above
    # ndf = pd.DataFrame(df, columns=columns).dropna(subset=['jobConfig.jobIterations'])
    ndf = pd.DataFrame(df, columns=columns)
    print(f"jobFilter ndf {ndf['jobConfig.jobIterations'].hasnans}")
    ids_df = ndf.loc[df['jobConfig.jobIterations'] == iterations ]
    return ids_df['uuid'].to_list()
```

Run the backend and frontend.

Open the filter drop down and select `Benchmark`.

Then open a drop down arrow from within a  `virt-density` record.

- How were the fix/results from this change verified? Please provide relevant screenshots or results.
I added print statements to `jobFilter()` to show show the `uuid` and `jobConfig.jobIteration` columns with and without my change. 

![Screenshot From 2025-02-25 14-16-35](https://github.com/user-attachments/assets/bf186431-377b-41c8-a2f5-4e2124f68ec0)
![Screenshot From 2025-02-25 14-17-26](https://github.com/user-attachments/assets/d5d1c156-434a-4563-870c-f260f0ac3a5f)

With my changes there are no missing values in the `jobConfig.jobIteration` column.

![Screenshot From 2025-02-25 14-20-31](https://github.com/user-attachments/assets/489bef86-2501-4043-b6e8-121bec5d61e7)

