### PR TITLE
Deploy staging app from `revamp`

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - revamp
 
 jobs:
   build:
@@ -17,7 +18,7 @@ jobs:
       uses: redhat-actions/buildah-build@v2
       with:
         image: frontend
-        context: frontend 
+        context: frontend
         tags: latest ${{ github.sha }}
         containerfiles: |
           ./frontend/frontend.containerfile


### PR DESCRIPTION
Enable early testing of `revamp` branch as we near completion.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Right now, CPT dashboard has two CD modes: a push to `main` triggers container builds (frontend and backend) to quay.io with the `latest` tag. The CD service deploys a changed `latest` tag to the `dashboard-dev` application instance. Creation of a GitHub tag triggers container builds with the `prod` tag, which in turn triggers deployment of the production `dashboard` application.

This simple change adds the `revamp` branch along with `main` for the `latest` tag build. Currently we're focusing on stabilizing `revamp` and not making big changes to `main`; having regular staging deployment from `revamp` makes more sense until we drop it to `main`, at which point this change could be reverted.

(If we do merge a change into `main` the staging instance could bounce back and forth; this probably isn't a significant issue as it's not really intended for long-term use.)

## Related Tickets & Documents

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

It's unfortunately difficult to test GitHub Actions prior to merge; at worst, this will only affect the `revamp` branch and can be easily reverted/altered if necessary.