### PR TITLE
Bug Fix Divide by Zero

### DIFF
--- a/backend/app/api/v1/endpoints/quay/quayGraphs.py
+++ b/backend/app/api/v1/endpoints/quay/quayGraphs.py
@@ -142,7 +142,7 @@ async def parseImageResults(data: dict):
     totals = {"latency": 0.0, "success_count": 0.0, "failure_count": 0.0}
     datapoints = data["aggregations"]["uuid"]["buckets"]
     # if sample size is zero, then our estimates are zero
-    if datapoints == 0:
+    if len(datapoints) == 0:
         return totals
     for each in datapoints:
         safe_add(each, totals, "latency", "latency")

--- a/backend/app/api/v1/endpoints/quay/quayGraphs.py
+++ b/backend/app/api/v1/endpoints/quay/quayGraphs.py
@@ -141,13 +141,16 @@ async def parseApiResults(data: dict):
 async def parseImageResults(data: dict):
     totals = {"latency": 0.0, "success_count": 0.0, "failure_count": 0.0}
     datapoints = data["aggregations"]["uuid"]["buckets"]
+    # if sample size is zero, then our estimates are zero
+    if datapoints == 0:
+        return totals
     for each in datapoints:
         safe_add(each, totals, "latency", "latency")
         safe_add(each, totals, "success_count", "success_count")
         safe_add(each, totals, "failure_count", "failure_count")
-    totals["latency"] /= max(len(datapoints), 1)
-    totals["success_count"] /= max(len(datapoints), 1)
-    totals["failure_count"] /= max(len(datapoints), 1)
+    totals["latency"] /=len(datapoints)
+    totals["success_count"] /= len(datapoints)
+    totals["failure_count"] /= len(datapoints)
     return totals
 
 

--- a/backend/app/api/v1/endpoints/quay/quayGraphs.py
+++ b/backend/app/api/v1/endpoints/quay/quayGraphs.py
@@ -145,9 +145,9 @@ async def parseImageResults(data: dict):
         safe_add(each, totals, "latency", "latency")
         safe_add(each, totals, "success_count", "success_count")
         safe_add(each, totals, "failure_count", "failure_count")
-    totals["latency"] /= len(datapoints)
-    totals["success_count"] /= len(datapoints)
-    totals["failure_count"] /= len(datapoints)
+    totals["latency"] /= max(len(datapoints), 1)
+    totals["success_count"] /= max(len(datapoints), 1)
+    totals["failure_count"] /= max(len(datapoints), 1)
     return totals
 
 

--- a/backend/app/api/v1/endpoints/quay/quayGraphs.py
+++ b/backend/app/api/v1/endpoints/quay/quayGraphs.py
@@ -148,7 +148,7 @@ async def parseImageResults(data: dict):
         safe_add(each, totals, "latency", "latency")
         safe_add(each, totals, "success_count", "success_count")
         safe_add(each, totals, "failure_count", "failure_count")
-    totals["latency"] /=len(datapoints)
+    totals["latency"] /= len(datapoints)
     totals["success_count"] /= len(datapoints)
     totals["failure_count"] /= len(datapoints)
     return totals


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In the Quay graphs, whenever a data sample has a zero quantity of data points the cpt-dashboard data server throws a divide by zero error. I wrapped the division with a call to `max(datapoints, 1)`. An alternative would be to return zero for these calculations if it is true that [zero buckets means there are no data points which means the data sample is empty](https://github.com/cloud-bulldozer/cpt-dashboard/blob/3a4019d42d3ab954b931e5a1d6d1f3ce407f6d0c/backend/app/api/v1/endpoints/quay/quayGraphs.py#L143).

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
I started the application. Clicked the Quay tab. Clicked several Quay tabs and monitored the data server's logs for divide by zero errors. I found none.
