### PR TITLE
Poetic cleanup

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -2064,4 +2064,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "6c4ce480ad4e6f2cf11ec7e00e3758302c338f957e4db67026a206198ebb7cd7"
+content-hash = "30bd1474732baa39b3315e683fb09a109393f064318f6ca15c2b4283f4ae6ad3"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,8 +1,15 @@
 [project]
 name = "openshift_perfscale_api"
+requires-python = "^3.9"
+dynamic = ["dependencies"]
 version = "0.1.1"
 description = "Python transformer of OpenShift performance and scale test results"
 authors = [{name = "mleader", email = "mleader@redhat.com"}]
+
+[tool.poetry]
+packages = [
+    { include = "app" }
+]
 
 [tool.poetry.dependencies]
 aiohttp = "^3.7.4"
@@ -12,6 +19,7 @@ elasticsearch = "7.13.4"
 fastapi = "^0.104.1"
 httptools = "^0.2.0"
 httpx = "^0.18.1"
+numpy = "1.26.4"
 orjson = "^3.5.3"
 pandas = "1.2.4"
 pydantic = "2.3.0"


### PR DESCRIPTION
Enhance `pyproject.toml` to fix `poetry install` and prevent `poetry update` from breaking the implicit Elasticsearch dependency on `numpy` being pre-2.0.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Our `poetry.lock` file specifies `numpy` 1.26.4, which is required by our Elasticsearch dependency -- however this is not constrained in `pyproject.toml`, so a `poetry update` will upgrade to 2.0.2, which removes an interface needed by Elasticsearch.

Also, due to Poetry 2.x changes, `poetry install` doesn't work on our current code base; this enhances `pyproject.toml` to fix that.

## Related Tickets & Documents

PANDA-819

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

`poetry install` and `poetry run` now work correctly in a local sandbox.