### PR TITLE
Update GitHub Actions to ubuntu-latest

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build and push image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/frontend-check.yaml
+++ b/.github/workflows/frontend-check.yaml
@@ -1,12 +1,12 @@
 name: Cypress end-to-end tests
-on: 
+on:
   push:
     branches:
       - main
   pull_request:
 jobs:
   install-gui:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,20 +27,20 @@ jobs:
 
   cypress-run:
     name: Cypress run
-    needs: 
+    needs:
       - install-gui
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: setup GUI containerized service dependencies
-        run: ./backend/tests/e2e_backend.sh        
+        run: ./backend/tests/e2e_backend.sh
 
       - name: Download the build folder
         uses: actions/download-artifact@v4
         with:
-          name: build        
+          name: build
           path: ./frontend/dist
 
       - name: Cypress run

--- a/.github/workflows/poetry-check.yaml
+++ b/.github/workflows/poetry-check.yaml
@@ -4,7 +4,7 @@ on: [ pull_request ]
 jobs:
   build:
     name: Check poetry lockfile
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
         - uses: actions/checkout@v3

--- a/.github/workflows/release-build-push.yaml
+++ b/.github/workflows/release-build-push.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build and push image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -18,7 +18,7 @@ jobs:
       uses: redhat-actions/buildah-build@v2
       with:
         image: frontend
-        context: frontend 
+        context: frontend
         tags: prod ${{ github.sha }}
         containerfiles: |
           ./frontend/frontend.containerfile


### PR DESCRIPTION
With 20.04 being retired, we need to update our Actions. For simplicity, I'm going with `unbuntu-latest` so we won't have to worry about this again.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

GitHub is retiring Ubuntu 20.04 runners, and randomly "browning out" (failing) actions referring to it leading up towards the April 15 shutoff.

Instead, we'll just use `ubuntu-latest`.

## Related Tickets & Documents

[PANDA-831](https://issues.redhat.com/browse/PANDA-831)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Pushing the PR will test the change!
