### PR TITLE
Reset page number on applying date and category filters

### DIFF
--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -161,10 +161,11 @@ class ElasticService:
                                 "data": response["hits"]["hits"],
                                 "total": response["hits"]["total"]["value"],
                             }
-                    combined_data = (previous_results.get("data") or []) + (
-                        new_results.get("data") or []
+
+                    unique_data = await self.remove_duplicates(
+                        (previous_results["data"] if "data" in previous_results else [])
+                        + (new_results["data"] if "data" in new_results else [])
                     )
-                    unique_data = await self.remove_duplicates(combined_data)
 
                     totalVal = previous_results.get("total", 0) + new_results.get(
                         "total", 0
@@ -190,7 +191,7 @@ class ElasticService:
                         }
             else:
                 """Handles queries that do not have a timestamp field"""
-                previous_results = []
+                previous_results = {}
                 if self.prev_es:
                     self.prev_index = self.prev_index_prefix + (
                         self.prev_index if indice is None else indice
@@ -218,10 +219,11 @@ class ElasticService:
                     "data": response["hits"]["hits"],
                     "total": response["hits"]["total"]["value"],
                 }
-                combined_data = (previous_results.get("data") or []) + (
-                    new_results.get("data") or []
+                unique_data = await self.remove_duplicates(
+                    (previous_results["data"] if "data" in previous_results else [])
+                    + (new_results["data"] if "data" in new_results else [])
                 )
-                unique_data = await self.remove_duplicates(combined_data)
+
                 prev_total = previous_results.get("total", 0)
                 new_total = new_results.get("total", 0)
                 totalVal = prev_total + new_total

--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -161,11 +161,10 @@ class ElasticService:
                                 "data": response["hits"]["hits"],
                                 "total": response["hits"]["total"]["value"],
                             }
-
-                    unique_data = await self.remove_duplicates(
-                        (previous_results["data"] if "data" in previous_results else [])
-                        + (new_results["data"] if "data" in new_results else [])
+                    combined_data = (previous_results.get("data") or []) + (
+                        new_results.get("data") or []
                     )
+                    unique_data = await self.remove_duplicates(combined_data)
 
                     totalVal = previous_results.get("total", 0) + new_results.get(
                         "total", 0
@@ -219,10 +218,10 @@ class ElasticService:
                     "data": response["hits"]["hits"],
                     "total": response["hits"]["total"]["value"],
                 }
-                unique_data = await self.remove_duplicates(
-                    (previous_results["data"] if "data" in previous_results else [])
-                    + (new_results["data"] if "data" in new_results else [])
+                combined_data = (previous_results.get("data") or []) + (
+                    new_results.get("data") or []
                 )
+                unique_data = await self.remove_duplicates(combined_data)
 
                 prev_total = previous_results.get("total", 0)
                 new_total = new_results.get("total", 0)

--- a/frontend/src/actions/homeActions.js
+++ b/frontend/src/actions/homeActions.js
@@ -1,6 +1,10 @@
 import * as API_ROUTES from "@/utils/apiConstants";
 import * as TYPES from "@/actions/types.js";
 
+import {
+  INITAL_OFFSET,
+  START_PAGE,
+} from "@/assets/constants/paginationConstants";
 import { appendDateFilter, appendQueryString } from "@/utils/helper";
 import {
   calculateSummary,
@@ -11,7 +15,6 @@ import {
 } from "./commonActions";
 
 import API from "@/utils/axiosInstance";
-import { INITAL_OFFSET } from "@/assets/constants/paginationConstants";
 import { setLastUpdatedTime } from "./headerActions";
 import { showFailureToast } from "@/actions/toastActions";
 
@@ -179,6 +182,7 @@ export const removeCPTAppliedFilters =
 
 export const applyFilters = () => (dispatch) => {
   dispatch(setCPTOffset(INITAL_OFFSET));
+  dispatch(setCPTPage(START_PAGE));
   dispatch(fetchOCPJobsData(true));
   dispatch(buildFilterData());
   dispatch(tableReCalcValues());
@@ -207,8 +211,10 @@ export const setCPTDateFilter =
 export const applyCPTDateFilter =
   (start_date, end_date, navigate) => (dispatch) => {
     dispatch(setCPTOffset(INITAL_OFFSET));
+    dispatch(setCPTPage(START_PAGE));
     dispatch(setCPTDateFilter(start_date, end_date, navigate));
     dispatch(fetchOCPJobsData());
+    dispatch(buildFilterData());
   };
 
 export const setCPTPage = (pageNo) => ({

--- a/frontend/src/actions/ocpActions.js
+++ b/frontend/src/actions/ocpActions.js
@@ -1,6 +1,10 @@
 import * as API_ROUTES from "@/utils/apiConstants";
 import * as TYPES from "./types.js";
 
+import {
+  INITAL_OFFSET,
+  START_PAGE,
+} from "@/assets/constants/paginationConstants";
 import { appendDateFilter, appendQueryString } from "@/utils/helper.js";
 import {
   calculateSummary,
@@ -11,7 +15,6 @@ import {
 } from "./commonActions";
 
 import API from "@/utils/axiosInstance";
-import { INITAL_OFFSET } from "@/assets/constants/paginationConstants";
 import { cloneDeep } from "lodash";
 import { setLastUpdatedTime } from "./headerActions";
 import { showFailureToast } from "./toastActions";
@@ -102,6 +105,7 @@ export const setOCPCatFilters = (category) => (dispatch, getState) => {
 
 export const applyFilters = () => (dispatch) => {
   dispatch(setOCPOffset(INITAL_OFFSET));
+  dispatch(setOCPPage(START_PAGE));
   dispatch(fetchOCPJobs());
   dispatch(buildFilterData());
   dispatch(tableReCalcValues());
@@ -176,6 +180,7 @@ export const setOCPDateFilter =
 export const applyOCPDateFilter =
   (start_date, end_date, navigate) => (dispatch) => {
     dispatch(setOCPOffset(INITAL_OFFSET));
+    dispatch(setOCPPage(START_PAGE));
     dispatch(setOCPDateFilter(start_date, end_date, navigate));
     dispatch(fetchOCPJobs());
     dispatch(buildFilterData());

--- a/frontend/src/actions/olsActions.js
+++ b/frontend/src/actions/olsActions.js
@@ -1,6 +1,10 @@
 import * as API_ROUTES from "@/utils/apiConstants";
 import * as TYPES from "@/actions/types.js";
 
+import {
+  INITAL_OFFSET,
+  START_PAGE,
+} from "@/assets/constants/paginationConstants";
 import { appendDateFilter, appendQueryString } from "@/utils/helper.js";
 import {
   calculateSummary,
@@ -11,7 +15,6 @@ import {
 } from "./commonActions";
 
 import API from "@/utils/axiosInstance";
-import { INITAL_OFFSET } from "@/assets/constants/paginationConstants";
 import { cloneDeep } from "lodash";
 import { setLastUpdatedTime } from "./headerActions";
 import { showFailureToast } from "@/actions/toastActions";
@@ -120,6 +123,7 @@ export const removeOLSAppliedFilters =
 
 export const applyFilters = () => (dispatch) => {
   dispatch(setOLSOffset(INITAL_OFFSET));
+  dispatch(setOLSPage(START_PAGE));
   dispatch(fetchOLSJobsData());
   dispatch(buildFilterData());
   dispatch(tableReCalcValues());
@@ -186,6 +190,7 @@ export const setOLSDateFilter =
 export const applyOLSDateFilter =
   (start_date, end_date, navigate) => (dispatch) => {
     dispatch(setOLSOffset(INITAL_OFFSET));
+    dispatch(setOLSPage(START_PAGE));
     dispatch(setOLSDateFilter(start_date, end_date, navigate));
     dispatch(fetchOLSJobsData());
     dispatch(buildFilterData());

--- a/frontend/src/actions/quayActions.js
+++ b/frontend/src/actions/quayActions.js
@@ -1,6 +1,10 @@
 import * as API_ROUTES from "@/utils/apiConstants";
 import * as TYPES from "@/actions/types.js";
 
+import {
+  INITAL_OFFSET,
+  START_PAGE,
+} from "@/assets/constants/paginationConstants";
 import { appendDateFilter, appendQueryString } from "@/utils/helper.js";
 import {
   calculateSummary,
@@ -11,7 +15,6 @@ import {
 } from "./commonActions";
 
 import API from "@/utils/axiosInstance";
-import { INITAL_OFFSET } from "@/assets/constants/paginationConstants";
 import { cloneDeep } from "lodash";
 import { setLastUpdatedTime } from "./headerActions";
 import { showFailureToast } from "@/actions/toastActions";
@@ -120,6 +123,7 @@ export const removeQuayAppliedFilters =
 
 export const applyFilters = () => (dispatch) => {
   dispatch(setQuayOffset(INITAL_OFFSET));
+  dispatch(setQuayPage(START_PAGE));
   dispatch(fetchQuayJobsData());
   dispatch(buildFilterData());
   dispatch(tableReCalcValues());
@@ -186,6 +190,7 @@ export const setQuayDateFilter =
 export const applyQuayDateFilter =
   (start_date, end_date, navigate) => (dispatch) => {
     dispatch(setQuayOffset(INITAL_OFFSET));
+    dispatch(setQuayPage(START_PAGE));
     dispatch(setQuayDateFilter(start_date, end_date, navigate));
     dispatch(fetchQuayJobsData());
     dispatch(buildFilterData());

--- a/frontend/src/actions/telcoActions.js
+++ b/frontend/src/actions/telcoActions.js
@@ -1,6 +1,10 @@
 import * as API_ROUTES from "@/utils/apiConstants";
 import * as TYPES from "@/actions/types.js";
 
+import {
+  INITAL_OFFSET,
+  START_PAGE,
+} from "@/assets/constants/paginationConstants";
 import { appendDateFilter, appendQueryString } from "@/utils/helper.js";
 import {
   calculateSummary,
@@ -11,7 +15,6 @@ import {
 } from "./commonActions";
 
 import API from "@/utils/axiosInstance";
-import { INITAL_OFFSET } from "@/assets/constants/paginationConstants";
 import { cloneDeep } from "lodash";
 import { setLastUpdatedTime } from "./headerActions";
 import { showFailureToast } from "@/actions/toastActions";
@@ -114,7 +117,7 @@ export const removeTelcoAppliedFilters =
   };
 export const applyFilters = () => (dispatch) => {
   dispatch(setTelcoOffset(INITAL_OFFSET));
-
+  dispatch(setTelcoPage(START_PAGE));
   dispatch(fetchTelcoJobsData());
   dispatch(buildFilterData());
   dispatch(tableReCalcValues());
@@ -187,8 +190,10 @@ export const setTelcoDateFilter =
 export const applyTelcoDateFilter =
   (start_date, end_date, navigate) => (dispatch) => {
     dispatch(setTelcoOffset(INITAL_OFFSET));
+    dispatch(setTelcoPage(START_PAGE));
     dispatch(setTelcoDateFilter(start_date, end_date, navigate));
     dispatch(fetchTelcoJobsData());
+    dispatch(buildFilterData());
   };
 
 export const getTelcoSummary = (countObj) => (dispatch) => {


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

On applying Date and category filters, data should be displayed from page 1. Additionally,  in `search.py` file, the previous_results is a dict but at one place it was declared as list so it was failing at few places.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.