### PR TITLE
Crucible service unit test coverage

### DIFF
--- a/backend/app/services/crucible_svc.py
+++ b/backend/app/services/crucible_svc.py
@@ -10,13 +10,14 @@ breakout subsets or collection periods as either raw data points, statistical
 aggregate, or Plotly graph format for UI display.
 """
 
-import time
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import logging
+import time
 from typing import Any, Iterator, Optional, Tuple, Union
 
-from elasticsearch import AsyncElasticsearch, NotFoundError
+from elasticsearch import AsyncElasticsearch
 from fastapi import HTTPException, status
 from pydantic import BaseModel
 
@@ -86,7 +87,7 @@ class Point:
     value: float
 
 
-colors = [
+COLOR_NAMES = [
     "black",
     "aqua",
     "blue",
@@ -272,6 +273,15 @@ class CrucibleService:
         "source",
     )
 
+    # Set up a Logger at class level rather than at each instance creation
+    formatter = logging.Formatter(
+        "%(asctime)s %(process)d:%(thread)d %(levelname)s %(module)s:%(lineno)d %(message)s"
+    )
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    logger = logging.getLogger("CrucibleService")
+    logger.addHandler(handler)
+
     def __init__(self, configpath: str = "crucible"):
         """Initialize a Crucible CDM (OpenSearch) connection.
 
@@ -291,10 +301,22 @@ class CrucibleService:
         self.auth = (self.user, self.password) if self.user or self.password else None
         self.url = self.cfg.get(configpath + ".url")
         self.elastic = AsyncElasticsearch(self.url, basic_auth=self.auth)
+        self.logger.info("Initializing CDM V7 service to %s", self.url)
 
     @staticmethod
     def _get_index(root: str) -> str:
+        """Expand the root index name to the full name"""
         return "cdmv7dev-" + root
+
+    @staticmethod
+    def _get(source: dict[str, Any], fields: list[str], default: Optional[Any] = None):
+        """Safely traverse nested dictionaries with a default value"""
+        r = source
+        last_missing = False
+        for f in fields:
+            last_missing = f not in r
+            r = r.get(f, {})
+        return default if last_missing else r
 
     @staticmethod
     def _split_list(alist: Optional[list[str]] = None) -> list[str]:
@@ -342,26 +364,24 @@ class CrucibleService:
                 return value
             elif isinstance(value, datetime):
                 return int(value.timestamp() * 1000.0)
-            elif isinstance(value, str):
+            else:
+                # If it's a stringified int, convert & return; otherwise try
+                # to decode as a date string.
                 try:
                     return int(value)
                 except ValueError:
                     pass
-                try:
-                    d = datetime.fromisoformat(value)
-                    return int(d.timestamp() * 1000.0)
-                except ValueError:
-                    pass
+                d = datetime.fromisoformat(value)
+                return int(d.timestamp() * 1000.0)
         except Exception as e:
-            print(f"normalizing {type(value).__name__} {value} failed with {str(e)}")
             raise HTTPException(
                 status.HTTP_400_BAD_REQUEST,
-                f"Date representation {value} is not a date string or timestamp",
+                f"Date representation {value} is not valid: {str(e)!r}",
             )
 
-    @staticmethod
+    @classmethod
     def _hits(
-        payload: dict[str, Any], fields: Optional[list[str]] = None
+        cls, payload: dict[str, Any], fields: Optional[list[str]] = None
     ) -> Iterator[dict[str, Any]]:
         """Helper to iterate through OpenSearch query matches
 
@@ -377,20 +397,19 @@ class CrucibleService:
         Returns:
             Yields each object from the "greatest hits" list
         """
-        if "hits" not in payload:
+        if "hits" not in payload or not isinstance(payload["hits"], dict):
             raise HTTPException(
                 status_code=500, detail=f"Attempt to iterate hits for {payload}"
             )
-        hits = payload.get("hits", {}).get("hits", [])
+        hits = cls._get(payload, ["hits", "hits"], [])
         for h in hits:
             source = h["_source"]
-            if fields:
-                for f in fields:
-                    source = source[f]
-            yield source
+            yield source if not fields else cls._get(source, fields)
 
-    @staticmethod
-    def _aggs(payload: dict[str, Any], aggregation: str) -> Iterator[dict[str, Any]]:
+    @classmethod
+    def _aggs(
+        cls, payload: dict[str, Any], aggregation: str
+    ) -> Iterator[dict[str, Any]]:
         """Helper to access OpenSearch aggregations
 
         Iteratively yields the name and value of each aggregation returned
@@ -403,18 +422,20 @@ class CrucibleService:
         Returns:
             Yields each aggregation from an aggregation bucket list
         """
-        if "aggregations" not in payload:
+        if "aggregations" not in payload or not isinstance(
+            payload["aggregations"], dict
+        ):
             raise HTTPException(
                 status_code=500,
                 detail=f"Attempt to iterate missing aggregations for {payload}",
             )
         aggs = payload["aggregations"]
-        if aggregation not in aggs:
+        if aggregation not in aggs or not isinstance(aggs[aggregation], dict):
             raise HTTPException(
                 status_code=500,
-                detail=f"Attempt to iterate missing aggregation {aggregation} for {payload}",
+                detail=f"Attempt to iterate missing aggregation {aggregation!r} for {payload}",
             )
-        for agg in aggs[aggregation]["buckets"]:
+        for agg in cls._get(aggs, [aggregation, "buckets"], []):
             yield agg
 
     @staticmethod
@@ -423,7 +444,9 @@ class CrucibleService:
         try:
             ts = int(timestamp)
         except Exception as e:
-            print(f"ERROR: invalid {timestamp!r}: {str(e)!r}")
+            CrucibleService.logger.warning(
+                "invalid timestamp %r: %r", timestamp, str(e)
+            )
             ts = 0
         return str(datetime.fromtimestamp(ts / 1000.00, timezone.utc))
 
@@ -581,7 +604,7 @@ class CrucibleService:
                 n, v = e.split("=", maxsplit=1)
             except ValueError:
                 raise HTTPException(
-                    status.HTTP_400_BAD_REQUEST, f"Filter item {e} must be '<k>=<v>'"
+                    status.HTTP_400_BAD_REQUEST, f"Filter item {e!r} must be '<k>=<v>'"
                 )
             filters.append({"term": {f"metric_desc.names.{n}": v}})
         return filters
@@ -656,7 +679,7 @@ class CrucibleService:
         )
 
     @classmethod
-    def _build_sort_terms(cls, sorters: Optional[list[str]]) -> list[dict[str, str]]:
+    def _build_sort_terms(cls, sorters: Optional[list[str]]) -> list[dict[str, Any]]:
         """Build sort term list
 
         Sorters may reference any native `run` index field and must specify
@@ -676,16 +699,16 @@ class CrucibleService:
                 if dir not in cls.DIRECTIONS:
                     raise HTTPException(
                         status.HTTP_400_BAD_REQUEST,
-                        f"Sort direction {dir!r} must be one of {','.join(DIRECTIONS)}",
+                        f"Sort direction {dir!r} must be one of {','.join(cls.DIRECTIONS)}",
                     )
                 if key not in cls.FIELDS:
                     raise HTTPException(
                         status.HTTP_400_BAD_REQUEST,
-                        f"Sort key {key!r} must be one of {','.join(FIELDS)}",
+                        f"Sort key {key!r} must be one of {','.join(cls.FIELDS)}",
                     )
-                sort_terms.append({f"run.{key}": dir})
+                sort_terms.append({f"run.{key}": {"order": dir}})
         else:
-            sort_terms = [{"run.begin": "asc"}]
+            sort_terms = [{"run.begin": {"order": "asc"}}]
         return sort_terms
 
     async def _search(
@@ -704,9 +727,11 @@ class CrucibleService:
         idx = self._get_index(index)
         start = time.time()
         value = await self.elastic.search(index=idx, body=query, **kwargs)
-        print(
-            f"QUERY on {idx} took {time.time() - start} seconds, "
-            f"hits: {value.get('hits', {}).get('total')}"
+        self.logger.info(
+            "QUERY on %s took %.3f seconds, hits: %d",
+            idx,
+            time.time() - start,
+            value.get("hits", {}).get("total"),
         )
         return value
 
@@ -777,6 +802,11 @@ class CrucibleService:
         422 HTTP error (UNPROCESSABLE CONTENT) with a response body showing
         the unsatisfied breakouts (name and available values).
 
+        TODO: Instead of either single metric or aggregation across multiple
+        metrics, we should support "breakouts", which would individually
+        process (graph, summarize, or list) data for each "loose" breakout
+        name. E.g., Busy-CPU might list per-core, or per-processor mode.
+
         Args:
             run: run ID
             metric: combined metric name (e.g., sar-net::packets-sec)
@@ -823,7 +853,7 @@ class CrucibleService:
         # We want to help filter a consistent summary, so only show those
         # breakout names with more than one value.
         response["names"] = {n: sorted(v) for n, v in names.items() if v and len(v) > 1}
-        response["periods"] = list(periods)
+        response["periods"] = sorted(periods)
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=response
         )
@@ -851,30 +881,26 @@ class CrucibleService:
             )
             start = None
             end = None
+            name = "<unknown>"
             for h in self._hits(matches):
                 p = h["period"]
-                st = p["begin"]
-                et = p["end"]
-
-                # If any period is missing a timestamp, use the run's timestamp
-                # instead to avoid blowing up on a CDM error.
-                if st is None:
-                    st = h["run"]["begin"]
-                if et is None:
-                    et = h["run"]["end"]
+                st = p.get("begin")
+                et = p.get("end")
+                if not st or not et:
+                    name = (
+                        f"run {self._get(h, ['run', 'benchmark'])}:"
+                        f"{self._get(h, ['run', 'begin'])},"
+                        f"iteration {self._get(h, ['iteration', 'num'])},"
+                        f"sample {self._get(h, ['sample', 'num'])}"
+                    )
                 if st and (not start or st < start):
                     start = st
                 if et and (not end or et > end):
                     end = et
             if start is None or end is None:
-                name = (
-                    f"{h['run']['benchmark']}:{h['run']['begin']}-"
-                    f"{h['iteration']['num']}-{h['sample']['num']}-"
-                    f"{p['name']}"
-                )
                 raise HTTPException(
                     status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    f"Unable to compute {name!r} time range {start!r} -> {end!r}",
+                    f"Unable to compute {name!r} time range: the run is missing period timestamps",
                 )
             return [
                 {"range": {"metric_data.begin": {"gte": str(start)}}},
@@ -901,7 +927,7 @@ class CrucibleService:
         filtered = await self.search(
             index, source="run.id", filters=filters, ignore_unavailable=True
         )
-        print(f"HITS: {filtered['hits']['hits']}")
+        self.logger.debug("HITS: %s", filtered["hits"]["hits"])
         return set([x for x in self._hits(filtered, ["run", "id"])])
 
     async def get_run_filters(self) -> dict[str, dict[str, list[str]]]:
@@ -1078,10 +1104,12 @@ class CrucibleService:
                 s = self._normalize_date(start)
                 results["startDate"] = datetime.fromtimestamp(
                     s / 1000.0, tz=timezone.utc
-                )
+                ).isoformat()
             if end:
                 e = self._normalize_date(end)
-                results["endDate"] = datetime.fromtimestamp(e / 1000.0, tz=timezone.utc)
+                results["endDate"] = datetime.fromtimestamp(
+                    e / 1000.0, tz=timezone.utc
+                ).isoformat()
 
             if s and e and s > e:
                 raise HTTPException(
@@ -1185,7 +1213,7 @@ class CrucibleService:
                 run["begin_date"] = self._format_timestamp(run["begin"])
                 run["end_date"] = self._format_timestamp(run["end"])
             except KeyError as e:
-                print(f"Missing 'run' key {str(e)} in {run}")
+                self.logger.warning("Missing 'run' key %r in %s", str(e), run)
                 run["begin_date"] = self._format_timestamp("0")
                 run["end_date"] = self._format_timestamp("0")
 
@@ -1254,8 +1282,11 @@ class CrucibleService:
             iter = param["iteration"]["id"]
             arg = param["param"]["arg"]
             val = param["param"]["val"]
-            if response.get(iter) and response.get(iter).get(arg):
-                print(f"Duplicate param {arg} for iteration {iter}")
+            old = self._get(response, [iter, arg])
+            if old:
+                self.logger.warning(
+                    "Duplicate param %s for iteration %s (%r, %r)", arg, iter, old, val
+                )
             response[iter][arg] = val
 
         # Filter out all parameter values that don't exist in all or which have
@@ -1313,11 +1344,9 @@ class CrucibleService:
         )
         samples = []
         for s in self._hits(hits):
-            print(f"SAMPLE's ITERATION {s['iteration']}")
             sample = s["sample"]
             sample["iteration"] = s["iteration"]["num"]
             sample["primary_metric"] = s["iteration"]["primary-metric"]
-            sample["status"] = s["iteration"]["status"]
             samples.append(sample)
         return samples
 
@@ -1372,61 +1401,6 @@ class CrucibleService:
             body.append(period)
         return body
 
-    async def get_timeline(self, run: str, **kwargs) -> dict[str, Any]:
-        """Report the relative timeline of a run
-
-        With nested object lists, show runs to iterations to samples to
-        periods.
-
-        Args:
-            run: run ID
-            kwargs: additional OpenSearch parameters
-        """
-        itr = await self.search(
-            index="iteration",
-            filters=[{"term": {"run.id": run}}],
-            **kwargs,
-            ignore_unavailable=True,
-        )
-        sam = await self.search(
-            index="sample",
-            filters=[{"term": {"run.id": run}}],
-            **kwargs,
-            ignore_unavailable=True,
-        )
-        per = await self.search(
-            index="period",
-            filters=[{"term": {"run.id": run}}],
-            **kwargs,
-            ignore_unavailable=True,
-        )
-        samples = defaultdict(list)
-        periods = defaultdict(list)
-
-        for s in self._hits(sam):
-            samples[s["iteration"]["id"]].append(s)
-        for p in self._hits(per):
-            periods[p["sample"]["id"]].append(p)
-
-        iterations = []
-        robj = {"id": run, "iterations": iterations}
-        body = {"run": robj}
-        for i in self._hits(itr):
-            if "begin" not in robj:
-                robj["begin"] = self._format_timestamp(i["run"]["begin"])
-                robj["end"] = self._format_timestamp(i["run"]["end"])
-            iteration = i["iteration"]
-            iterations.append(iteration)
-            iteration["samples"] = []
-            for s in samples.get(iteration["id"], []):
-                sample = s["sample"]
-                sample["periods"] = []
-                for pr in periods.get(sample["id"], []):
-                    period = self._format_period(pr["period"])
-                    sample["periods"].append(period)
-                iteration["samples"].append(sample)
-        return body
-
     async def get_metrics_list(self, run: str, **kwargs) -> dict[str, Any]:
         """Return a list of metrics available for a run
 
@@ -1466,12 +1440,14 @@ class CrucibleService:
             if name in met:
                 record = met[name]
             else:
-                record = {"periods": [], "breakouts": defaultdict(set)}
+                record = {"periods": [], "breakouts": defaultdict(list)}
                 met[name] = record
             if "period" in h:
                 record["periods"].append(h["period"]["id"])
             for n, v in desc["names"].items():
-                record["breakouts"][n].add(v)
+                # mimic a set, since the set type doesn't serialize
+                if v not in record["breakouts"][n]:
+                    record["breakouts"][n].append(v)
         return met
 
     async def get_metric_breakouts(
@@ -1527,8 +1503,8 @@ class CrucibleService:
                 f"Metric name {metric_name} not found for run {run}",
             )
         classes = set()
-        response = {"label": metric, "class": classes}
-        breakouts = defaultdict(set)
+        response = {"label": metric}
+        breakouts = defaultdict(list)
         pl = set()
         for m in self._hits(metrics):
             desc = m["metric_desc"]
@@ -1539,14 +1515,15 @@ class CrucibleService:
             if "period" in m:
                 pl.add(m["period"]["id"])
             for n, v in desc["names"].items():
-                breakouts[n].add(v)
+                if v not in breakouts[n]:
+                    breakouts[n].append(v)
         # We want to help filter a consistent summary, so only show those
         # names with more than one value.
         if len(pl) > 1:
-            response["periods"] = pl
+            response["periods"] = sorted(pl)
+        response["class"] = sorted(classes)
         response["breakouts"] = {n: v for n, v in breakouts.items() if len(v) > 1}
-        duration = time.time() - start
-        print(f"Processing took {duration} seconds")
+        self.logger.info("Processing took %.3f seconds", time.time() - start)
         return response
 
     async def get_metrics_data(
@@ -1607,6 +1584,9 @@ class CrucibleService:
         filters.extend(await self._build_timestamp_range_filters(periods))
 
         response = []
+
+        # NOTE -- _get_metric_ids already failed if we found multiple IDs but
+        # aggregation wasn't specified.
         if len(ids) > 1:
             # Find the minimum sample interval of the selected metrics
             aggdur = await self.search(
@@ -1645,8 +1625,7 @@ class CrucibleService:
             for h in self._hits(data, ["metric_data"]):
                 response.append(self._format_data(h))
         response.sort(key=lambda a: a["end"])
-        duration = time.time() - start
-        print(f"Processing took {duration} seconds")
+        self.logger.info("Processing took %.3f seconds", time.time() - start)
         return response
 
     async def get_metrics_summary(
@@ -1687,8 +1666,7 @@ class CrucibleService:
             filters=filters,
             aggregations={"score": {"stats": {"field": "metric_data.value"}}},
         )
-        duration = time.time() - start
-        print(f"Processing took {duration} seconds")
+        self.logger.info("Processing took %.3f seconds", time.time() - start)
         return data["aggregations"]["score"]
 
     async def _graph_title(
@@ -1942,9 +1920,9 @@ class CrucibleService:
             if g.color:
                 color = g.color
             else:
-                color = colors[cindex]
+                color = COLOR_NAMES[cindex]
                 cindex += 1
-                if cindex >= len(colors):
+                if cindex >= len(COLOR_NAMES):
                     cindex = 0
             graphitem = {
                 "x": x,
@@ -1989,6 +1967,5 @@ class CrucibleService:
                 axes[metric] = yref
             graphitem["yaxis"] = yref
             graphlist.append(graphitem)
-        duration = time.time() - start
-        print(f"Processing took {duration} seconds")
+        self.logger.info("Processing took %.3f seconds", time.time() - start)
         return {"data": graphlist, "layout": layout}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -68,7 +68,7 @@ allowlist_externals = ["bash", "echo", "coverage"]
 commands = [
     ["echo", "{env:COVERAGE}"],
     ["pip", "list"],
-    ["pytest", "-s", "--cov-branch", "--cov=app", "tests"],
+    ["pytest", "-s", "--cov-branch", "--cov=app", "{posargs}", "tests"],
     ["coverage", "html", "--directory={env:COVERAGE}/html"],
     ["bash", "-c", "coverage report --format=markdown >{env:COVERAGE}/coverage.txt"],
 ]

--- a/backend/tests/fake_elastic.py
+++ b/backend/tests/fake_elastic.py
@@ -1,12 +1,36 @@
+from collections import defaultdict
+from dataclasses import dataclass
 from typing import Any, Optional, Union
 
 from elasticsearch import AsyncElasticsearch
+
+
+@dataclass
+class Request:
+    index: str
+    body: dict[str, Any]
+    doc_type: Optional[str] = None
+    params: Optional[Any] = None
+    headers: Optional[Any] = None
+    kwargs: Optional[dict[str, Any]] = None
+
+    def __eq__(self, other) -> bool:
+        iok = self.index == other.index
+        bok = self.body == other.body
+        dok = self.doc_type == other.doc_type
+        pok = self.params == other.params
+        hok = self.headers == other.headers
+
+        # make empty dict and None match
+        kok = (not self.kwargs and not other.kwargs) or self.kwargs == other.kwargs
+        return iok and bok and dok and pok and hok and kok
 
 
 class FakeAsyncElasticsearch(AsyncElasticsearch):
     hosts: Union[str, list[str]]
     args: dict[str, Any]
     closed: bool
+    requests: list[Request]
 
     # This fake doesn't try to mimic Opensearch query and aggregation logic:
     # instead, the "data" is pre-loaded with a JSON response body that will
@@ -18,20 +42,37 @@ class FakeAsyncElasticsearch(AsyncElasticsearch):
         self.hosts = hosts
         self.args = kwargs
         self.closed = False
-        self.data = {}
+        self.data = defaultdict(list)
+        self.requests = []
 
     # Testing helpers to manage fake searches
     def set_query(
         self,
         root_index: str,
         hit_list: Optional[list[dict[str, Any]]] = None,
-        aggregation_list: Optional[dict[str, Any]] = None,
+        aggregations: Optional[dict[str, Any]] = None,
         version: int = 7,
+        repeat: int = 1,
     ):
+        """Add a canned response to an Opensearch query
+
+        The overall response and items in the hit and aggregation lists will be
+        augmented with the usual boilerplate.
+
+        Multiple returns for a single index can be queued, in order, via
+        successive calls. To return the same result on multiple calls, specify
+        a "repeat" value greater than 1.
+
+        Args:
+            root_index: CDM index name (run, period, etc)
+            hit_list: list of hit objects to be returned
+            aggregation_list: list of aggregation objects to return
+            version: CDM version
+            repeat:
+        """
         ver = f"v{version:d}dev"
         index = f"cdm{ver}-{root_index}"
         hits = []
-        aggregations = None
         if hit_list:
             for d in hit_list:
                 source = d
@@ -44,16 +85,18 @@ class FakeAsyncElasticsearch(AsyncElasticsearch):
                         "_source": source,
                     }
                 )
-        if aggregation_list:
-            aggregations = {
-                k: {
-                    "doc_count_error_upper_bound": 0,
-                    "sum_other_doc_count": 0,
-                    "buckets": v,
-                }
-                for k, v in aggregation_list.items()
-            }
-        self.data[index] = {
+        aggregate_response = {}
+        if aggregations:
+            for agg, val in aggregations.items():
+                if isinstance(val, list):
+                    aggregate_response[agg] = {
+                        "doc_count_error_upper_bound": 0,
+                        "sum_other_doc_count": 0,
+                        "buckets": val,
+                    }
+                else:
+                    aggregate_response[agg] = val
+        response = {
             "took": 1,
             "timed_out": False,
             "_shards": {"total": 1, "successful": 1, "skipped": 0, "failed": 0},
@@ -63,8 +106,10 @@ class FakeAsyncElasticsearch(AsyncElasticsearch):
                 "hits": hits,
             },
         }
-        if aggregations:
-            self.data[index]["aggregations"] = aggregations
+        if aggregate_response:
+            response["aggregations"] = aggregate_response
+        for c in range(repeat):
+            self.data[index].append(response)
 
     # Faked AsyncElasticsearch methods
     async def close(self):
@@ -79,9 +124,34 @@ class FakeAsyncElasticsearch(AsyncElasticsearch):
     async def search(
         self, body=None, index=None, doc_type=None, params=None, headers=None, **kwargs
     ):
-        if index in self.data:
-            target = self.data[index]
-            del self.data[index]
+        """Return a canned response to a search query.
+
+        Args:
+            body: query body
+            index: Opensearch index name
+            doc_type: document type (rarely used)
+            params: Opensearch search parameters (rarely used)
+            headers: HTTP headers (rarely used)
+            kwargs: whatever else you might pass to search
+
+        Only the index is used here; to verify the correct Opensearch query
+        bodies and parameters, the full request is recorded for inspection.
+
+        Return:
+            A JSON dict with the first canned result for the index, or an error
+        """
+        self.requests.append(
+            Request(
+                index=index,
+                body=body,
+                doc_type=doc_type,
+                params=params,
+                headers=headers,
+                kwargs=kwargs,
+            )
+        )
+        if index in self.data and len(self.data[index]) > 0:
+            target = self.data[index].pop(0)
             return target
         return {
             "error": {

--- a/backend/tests/test_crucible.py
+++ b/backend/tests/test_crucible.py
@@ -1,11 +1,21 @@
+from collections import defaultdict
+from datetime import datetime, timezone
+import json
+
 from elasticsearch import AsyncElasticsearch
 from fastapi import HTTPException
 import pytest
-from vyper import Vyper
 
 import app.config
-from app.services.crucible_svc import CommonParams, CrucibleService, Parser
-from tests.fake_elastic import FakeAsyncElasticsearch
+from app.services.crucible_svc import (
+    CommonParams,
+    CrucibleService,
+    Graph,
+    GraphList,
+    Parser,
+)
+from tests.fake_elastic import FakeAsyncElasticsearch, Request
+from vyper import Vyper
 
 
 @pytest.fixture
@@ -86,19 +96,87 @@ class TestCommonParams:
         assert {"one": 1} == c.render()
 
 
-class TestCrucible:
+class TestList:
 
-    async def test_create(self, fake_crucible):
-        """Create and close a CrucibleService instance"""
+    @pytest.mark.parametrize(
+        "input,output",
+        (
+            (None, []),
+            (["a"], ["a"]),
+            (["a", "b"], ["a", "b"]),
+            (["a,b"], ["a", "b"]),
+            (["a", "b,c", "d"], ["a", "b", "c", "d"]),
+        ),
+    )
+    def test_split_empty(self, input, output):
+        assert output == CrucibleService._split_list(input)
 
-        assert fake_crucible
-        assert isinstance(fake_crucible, CrucibleService)
-        assert isinstance(fake_crucible.elastic, AsyncElasticsearch)
-        assert app.config.get_config().get("TEST.url") == fake_crucible.url
-        elastic = fake_crucible.elastic
-        await fake_crucible.close()
-        assert fake_crucible.elastic is None
-        assert elastic.closed
+
+class TestFormatters:
+
+    @pytest.mark.parametrize(
+        "input",
+        (
+            "2024-09-12 18:29:35.123000+00:00",
+            datetime.fromisoformat("2024-09-12 18:29:35.123000+00:00"),
+            "1726165775123",
+            1726165775123,
+        ),
+    )
+    def test_normalize_date(self, input):
+        assert 1726165775123 == CrucibleService._normalize_date(input)
+
+    def test_normalize_date_bad(self):
+        with pytest.raises(HTTPException) as e:
+            CrucibleService._normalize_date([])
+        assert 400 == e.value.status_code
+        assert "Date representation [] is not a date string or timestamp"
+
+    @pytest.mark.parametrize(
+        "input,output",
+        (
+            ("abc", "1970-01-01 00:00:00+00:00"),
+            ("1726165775123", "2024-09-12 18:29:35.123000+00:00"),
+            (1726165775123, "2024-09-12 18:29:35.123000+00:00"),
+        ),
+    )
+    def test_format_timestamp(self, input, output):
+        assert output == CrucibleService._format_timestamp(input)
+
+    def test_format_data(self):
+        begin = 1726165775123
+        duration = 10244
+        raw = {
+            "begin": str(begin),
+            "end": str(begin + duration),
+            "duration": str(duration),
+            "value": "100.3",
+        }
+        expect = {
+            "begin": "2024-09-12 18:29:35.123000+00:00",
+            "end": "2024-09-12 18:29:45.367000+00:00",
+            "duration": 10.244,
+            "value": 100.3,
+        }
+        assert expect == CrucibleService._format_data(raw)
+
+    def test_format_period(self):
+        raw = {
+            "begin": "1726165775123",
+            "end": "1726165785234",
+            "id": "ABC-123",
+            "name": "measurement",
+        }
+        expect = {
+            "begin": "2024-09-12 18:29:35.123000+00:00",
+            "end": "2024-09-12 18:29:45.234000+00:00",
+            "id": "ABC-123",
+            "name": "measurement",
+        }
+        assert expect == CrucibleService._format_period(raw)
+
+
+class TestHits:
 
     def test_no_hits(self):
         """Expect an exception because 'hits' is missing"""
@@ -113,7 +191,7 @@ class TestCrucible:
         """Expect successful iteration of no hits"""
 
         for a in CrucibleService._hits({"hits": {"hits": []}}):
-            assert f"Unexpected result {type(a)}"
+            assert f"Unexpected result {a}"
 
     def test_hits(self):
         """Test that iteration through hits works"""
@@ -131,6 +209,371 @@ class TestCrucible:
             CrucibleService._hits({"hits": {"hits": payload}}, ["f"])
         )
 
+
+class TestAggregates:
+
+    def test_no_aggregations(self):
+        """Expect an exception if the aggregations are missing"""
+        with pytest.raises(HTTPException) as e:
+            for a in CrucibleService._aggs({}, "agg"):
+                assert f"Unexpected result {a}"
+        assert 500 == e.value.status_code
+        assert "Attempt to iterate missing aggregations for {}" == e.value.detail
+
+    def test_missing_agg(self):
+        """Expect an exception if the aggregations are missing"""
+
+        payload = {"aggregations": {}}
+        with pytest.raises(HTTPException) as e:
+            for a in CrucibleService._aggs(payload, "agg"):
+                assert f"Unexpected result {a}"
+        assert 500 == e.value.status_code
+        assert (
+            f"Attempt to iterate missing aggregation 'agg' for {payload}"
+            == e.value.detail
+        )
+
+    def test_empty_aggs(self):
+        """Expect successful iteration of no aggregation data"""
+
+        for a in CrucibleService._aggs(
+            {"aggregations": {"agg": {"buckets": []}}}, "agg"
+        ):
+            assert f"Unexpected result {a}"
+
+    def test_aggs(self):
+        """Test that iteration through aggregations works"""
+
+        expected = [{"key": 1, "doc_count": 2}, {"key": 2, "doc_count": 5}]
+        payload = {
+            "hits": {"total": {"value": 0}, "hits": []},
+            "aggregations": {
+                "agg": {
+                    "buckets": [{"key": 1, "doc_count": 2}, {"key": 2, "doc_count": 5}]
+                }
+            },
+        }
+        assert expected == list(CrucibleService._aggs(payload, "agg"))
+
+
+class TestFilterBuilders:
+
+    @pytest.mark.parametrize(
+        "filters,terms",
+        (
+            (
+                ["param:v=1", "tag:x='one two'", "run:email='d@e.c'"],
+                (
+                    [
+                        {
+                            "dis_max": {
+                                "queries": [
+                                    {
+                                        "bool": {
+                                            "must": [
+                                                {
+                                                    "term": {
+                                                        "param.arg": "v",
+                                                    },
+                                                },
+                                                {
+                                                    "term": {
+                                                        "param.val": "1",
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                    [
+                        {
+                            "dis_max": {
+                                "queries": [
+                                    {
+                                        "bool": {
+                                            "must": [
+                                                {
+                                                    "term": {
+                                                        "tag.name": "x",
+                                                    },
+                                                },
+                                                {
+                                                    "term": {
+                                                        "tag.val": "one two",
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                    [
+                        {
+                            "term": {
+                                "run.email": "d@e.c",
+                            },
+                        },
+                    ],
+                ),
+            ),
+            (
+                ["param:v~a"],
+                (
+                    [
+                        {
+                            "dis_max": {
+                                "queries": [
+                                    {
+                                        "bool": {
+                                            "must": [
+                                                {
+                                                    "term": {
+                                                        "param.arg": "v",
+                                                    },
+                                                },
+                                                {
+                                                    "regexp": {
+                                                        "param.val": ".*a.*",
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                    None,
+                    None,
+                ),
+            ),
+            (
+                ["tag:v~a"],
+                (
+                    None,
+                    [
+                        {
+                            "dis_max": {
+                                "queries": [
+                                    {
+                                        "bool": {
+                                            "must": [
+                                                {
+                                                    "term": {
+                                                        "tag.name": "v",
+                                                    },
+                                                },
+                                                {
+                                                    "regexp": {
+                                                        "tag.val": ".*a.*",
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                    None,
+                ),
+            ),
+        ),
+    )
+    def test_build_filter_options(self, filters, terms):
+        assert terms == CrucibleService._build_filter_options(filters)
+
+    def test_build_filter_bad_key(self):
+        with pytest.raises(HTTPException) as e:
+            CrucibleService._build_filter_options(["foobar:x=y"])
+        assert 400 == e.value.status_code
+        assert "unknown filter namespace 'foobar'" == e.value.detail
+
+    def test_build_name_filters(self):
+        assert [
+            {"term": {"metric_desc.names.name": "1"}}
+        ] == CrucibleService._build_name_filters(["name=1"])
+
+    def test_build_name_filters_bad(self):
+        with pytest.raises(HTTPException) as e:
+            CrucibleService._build_name_filters(["xya:x"])
+        assert 400 == e.value.status_code
+        assert "Filter item 'xya:x' must be '<k>=<v>'"
+
+    @pytest.mark.parametrize("periods", ([], ["10"], ["10", "20"]))
+    def test_build_period_filters(self, periods):
+        expected = (
+            []
+            if not periods
+            else [
+                {
+                    "dis_max": {
+                        "queries": [
+                            {"bool": {"must_not": {"exists": {"field": "period"}}}},
+                            {"terms": {"period.id": periods}},
+                        ]
+                    }
+                }
+            ]
+        )
+        assert expected == CrucibleService._build_period_filters(periods)
+
+    @pytest.mark.parametrize(
+        "term,message",
+        (
+            (
+                "foo:asc",
+                "Sort key 'foo' must be one of begin,benchmark,desc,email,end,harness,host,id,name,source",
+            ),
+            ("email:up", "Sort direction 'up' must be one of asc,desc"),
+        ),
+    )
+    def test_build_sort_filters_error(self, term, message):
+        with pytest.raises(HTTPException) as exc:
+            CrucibleService._build_sort_terms([term])
+        assert 400 == exc.value.status_code
+        assert message == exc.value.detail
+
+    @pytest.mark.parametrize(
+        "sort,terms",
+        (
+            ([], (("run.begin", {"order": "asc"}),)),
+            (["email:asc"], (("run.email", {"order": "asc"}),)),
+            (
+                ["email:desc", "name:asc"],
+                (("run.email", {"order": "desc"}), ("run.name", {"order": "asc"})),
+            ),
+        ),
+    )
+    def test_build_sort_filters(self, sort, terms):
+        expected = [{t[0]: t[1]} for t in terms]
+        assert expected == CrucibleService._build_sort_terms(sort)
+
+    @pytest.mark.parametrize(
+        "periods,result",
+        (
+            (
+                [
+                    {
+                        "period": {
+                            "id": "one",
+                            "begin": "1733505934677",
+                            "end": "1733507347857",
+                        }
+                    }
+                ],
+                [
+                    {"range": {"metric_data.begin": {"gte": "1733505934677"}}},
+                    {"range": {"metric_data.end": {"lte": "1733507347857"}}},
+                ],
+            ),
+            (None, []),
+        ),
+    )
+    async def test_build_timestamp_filter(
+        self, fake_crucible: CrucibleService, periods, result
+    ):
+        plist = None
+        if periods:
+            fake_crucible.elastic.set_query("period", periods)
+            plist = [p["period"]["id"] for p in periods]
+        assert result == await fake_crucible._build_timestamp_range_filters(plist)
+
+    @pytest.mark.parametrize(
+        "period,name",
+        (
+            ({"period": {"id": "one"}}, "run None:None,iteration None,sample None"),
+            (
+                {
+                    "run": {"id": "rid", "benchmark": "test", "begin": "1234"},
+                    "iteration": {"id": "iid", "num": 1},
+                    "sample": {"id": "sid", "num": 1},
+                    "period": {"id": "one", "begin": "5423"},
+                },
+                "run test:1234,iteration 1,sample 1",
+            ),
+        ),
+    )
+    async def test_build_timestamp_filter_bad(
+        self, fake_crucible: CrucibleService, period, name
+    ):
+        fake_crucible.elastic.set_query("period", [period])
+        with pytest.raises(HTTPException) as exc:
+            await fake_crucible._build_timestamp_range_filters(["one"])
+        assert 422 == exc.value.status_code
+        assert (
+            f"Unable to compute '{name}' time range: the run is missing period timestamps"
+            == exc.value.detail
+        )
+
+
+class TestCrucible:
+
+    async def test_create(self, fake_crucible):
+        """Create and close a CrucibleService instance"""
+
+        assert fake_crucible
+        assert isinstance(fake_crucible, CrucibleService)
+        assert isinstance(fake_crucible.elastic, AsyncElasticsearch)
+        assert app.config.get_config().get("TEST.url") == fake_crucible.url
+        elastic = fake_crucible.elastic
+        await fake_crucible.close()
+        assert fake_crucible.elastic is None
+        assert elastic.closed
+
+    async def test_search_args(self, fake_crucible: CrucibleService):
+        await fake_crucible.search(
+            "run",
+            [{"term": "a"}],
+            [{"x": {"field": "a"}}],
+            [{"key": "asc"}],
+            "run",
+            42,
+            69,
+            x=2,
+            z=3,
+        )
+        assert [
+            Request(
+                "cdmv7dev-run",
+                {
+                    "_source": "run",
+                    "aggs": [
+                        {
+                            "x": {
+                                "field": "a",
+                            },
+                        },
+                    ],
+                    "from": 69,
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": "a",
+                                },
+                            ],
+                        },
+                    },
+                    "size": 42,
+                    "sort": [
+                        {
+                            "key": "asc",
+                        },
+                    ],
+                },
+                None,
+                None,
+                None,
+                {"x": 2, "z": 3},
+            )
+        ] == fake_crucible.elastic.requests
+
     async def test_metric_ids_none(self, fake_crucible):
         """A simple query for failure matching metric IDs"""
 
@@ -141,13 +584,21 @@ class TestCrucible:
         assert "No matches for source::type" == e.value.detail
 
     @pytest.mark.parametrize(
-        "found,expected",
+        "found,expected,aggregate",
         (
             (
                 [
                     {"metric_desc": {"id": "one-metric"}},
                 ],
                 ["one-metric"],
+                False,
+            ),
+            (
+                [
+                    {"metric_desc": {"id": "one-metric"}},
+                ],
+                ["one-metric"],
+                True,
             ),
             (
                 [
@@ -155,18 +606,63 @@ class TestCrucible:
                     {"metric_desc": {"id": "two-metric"}},
                 ],
                 ["one-metric", "two-metric"],
+                True,
             ),
         ),
     )
-    async def test_metric_ids(self, fake_crucible, found, expected):
+    async def test_metric_ids(self, fake_crucible, found, expected, aggregate):
         """A simple query for matching metric IDs"""
 
         fake_crucible.elastic.set_query("metric_desc", found)
         assert expected == await fake_crucible._get_metric_ids(
             "runid",
             "source::type",
-            aggregate=len(expected) > 1,
+            aggregate=aggregate,
         )
+
+    @pytest.mark.parametrize(
+        "found,message",
+        (
+            (
+                [
+                    {"metric_desc": {"id": "one-metric", "names": {"john": "yes"}}},
+                    {"metric_desc": {"id": "two-metric", "names": {"john": "no"}}},
+                ],
+                (2, [], {"john": ["no", "yes"]}),
+            ),
+            (
+                [
+                    {
+                        "period": {"id": "p1"},
+                        "metric_desc": {"id": "three-metric", "names": {"john": "yes"}},
+                    },
+                    {"metric_desc": {"id": "four-metric", "names": {"fred": "why"}}},
+                    {
+                        "period": {"id": "p2"},
+                        "metric_desc": {"id": "five-metric", "names": {"john": "sure"}},
+                    },
+                    {"metric_desc": {"id": "six-metric", "names": {"john": "maybe"}}},
+                ],
+                (4, ["p1", "p2"], {"john": ["maybe", "sure", "yes"]}),
+            ),
+        ),
+    )
+    async def test_metric_ids_unproc(self, fake_crucible, found, message):
+        """Test matching metric IDs with lax criteria"""
+
+        fake_crucible.elastic.set_query("metric_desc", found)
+        with pytest.raises(HTTPException) as exc:
+            await fake_crucible._get_metric_ids(
+                "runid",
+                "source::type",
+                aggregate=False,
+            )
+        assert 422 == exc.value.status_code
+        assert {
+            "message": f"More than one metric ({message[0]}) means you should add breakout filters or aggregate.",
+            "periods": message[1],
+            "names": message[2],
+        } == exc.value.detail
 
     async def test_run_filters(self, fake_crucible):
         """Test aggregations
@@ -177,7 +673,7 @@ class TestCrucible:
 
         fake_crucible.elastic.set_query(
             "tag",
-            aggregation_list={
+            aggregations={
                 "key": [
                     {
                         "key": "topology",
@@ -217,7 +713,7 @@ class TestCrucible:
         )
         fake_crucible.elastic.set_query(
             "param",
-            aggregation_list={
+            aggregations={
                 "key": [
                     {
                         "key": "bucket",
@@ -233,7 +729,7 @@ class TestCrucible:
         )
         fake_crucible.elastic.set_query(
             "run",
-            aggregation_list={
+            aggregations={
                 "begin": [{"key": 123456789, "doc_count": 1}],
                 "benchmark": [{"key": "ilab", "doc_count": 25}],
                 "desc": [],
@@ -264,3 +760,1332 @@ class TestCrucible:
         assert sorted(filters["run"]["benchmark"]) == ["ilab"]
         assert sorted(filters["run"]["email"]) == ["me@example.com", "you@example.com"]
         assert sorted(filters["run"]["host"]) == ["one.example.com", "two.example.com"]
+
+    async def test_get_run_ids(self, fake_crucible: CrucibleService):
+        """_get_run_ids
+
+        This is just straightline code coverage as there's no point in mocking
+        the filters.
+        """
+        fake_crucible.elastic.set_query(
+            "period",
+            [{"run": {"id": "one"}}, {"run": {"id": "two"}}, {"run": {"id": "three"}}],
+        )
+        assert {"one", "two", "three"} == await fake_crucible._get_run_ids(
+            "period", [{"term": {"period.name": "measurement"}}]
+        )
+
+    async def test_get_runs_none(self, fake_crucible: CrucibleService):
+        """Test run summary"""
+        fake_crucible.elastic.set_query("run", [])
+        fake_crucible.elastic.set_query("iteration", [])
+        fake_crucible.elastic.set_query("tag", [])
+        fake_crucible.elastic.set_query("param", [])
+        assert {
+            "count": 0,
+            "offset": 0,
+            "results": [],
+            "sort": [],
+            "total": 0,
+        } == await fake_crucible.get_runs()
+
+    async def test_get_runs_time_reverse(self, fake_crucible: CrucibleService):
+        """Test run summary"""
+        fake_crucible.elastic.set_query("run", [])
+        fake_crucible.elastic.set_query("iteration", [])
+        fake_crucible.elastic.set_query("tag", [])
+        fake_crucible.elastic.set_query("param", [])
+        with pytest.raises(HTTPException) as exc:
+            await fake_crucible.get_runs(start="2025-01-01", end="2024-01-01")
+        assert 422 == exc.value.status_code
+        assert {
+            "error": "Invalid date format, start_date must be less than end_date"
+        } == exc.value.detail
+
+    @pytest.mark.parametrize(
+        "args,miss,notag,noparam",
+        (
+            ({}, False, False, False),
+            ({"size": 2, "offset": 1}, False, False, False),
+            ({"start": "2024-01-01"}, False, False, False),
+            ({"end": "2024-02-01"}, False, False, False),
+            ({"start": "2024-01-01", "end": "2025-01-01"}, False, False, False),
+            ({"sort": ["end:desc"]}, False, False, False),
+            (
+                {"filter": ["tag:a=42", "param:z=xyzzy", "run:benchmark=test"]},
+                False,
+                False,
+                False,
+            ),
+            ({"filter": ["tag:a=42", "param:z=xyzzy"]}, True, False, False),
+            ({"filter": ["tag:a=42", "param:z=xyzzy"]}, False, True, False),
+            ({"filter": ["tag:a=42", "param:z=xyzzy"]}, False, False, True),
+        ),
+    )
+    async def test_get_runs_queries(
+        self, args, miss, notag, noparam, fake_crucible: CrucibleService
+    ):
+        """Test processing of various query parameters
+
+        Note, this isn't really testing "behavior" of the filters, which is all
+        in Opensearch, just the CPT service's handling of the query parameters.
+
+        TBD: This should really verify the generated Opensearch query filters,
+        although that's mostly covered by earlier tests.
+        """
+        runs = [
+            {"run": {"id": "r1", "begin": "0", "end": "5000", "benchmark": "test"}},
+        ]
+        if miss:
+            # Add additional runs which will be rejected by filters
+            runs.extend(
+                [
+                    {
+                        "run": {
+                            "id": "r2",
+                            "begin": "110",
+                            "end": "7000",
+                            "benchmark": "test",
+                        }
+                    },
+                    {
+                        "run": {
+                            "id": "r3",
+                            "begin": "110",
+                            "end": "6000",
+                            "benchmark": "test",
+                        }
+                    },
+                ]
+            )
+        fake_crucible.elastic.set_query("run", runs)
+        fake_crucible.elastic.set_query(
+            "iteration",
+            [
+                {
+                    "run": {"id": "r1"},
+                    "iteration": {
+                        "id": "i1",
+                        "num": 1,
+                        "primary-period": "tp",
+                        "primary-metric": "src::tst1",
+                        "status": "pass",
+                    },
+                },
+                {
+                    "run": {"id": "r1"},
+                    "iteration": {
+                        "id": "i2",
+                        "num": 2,
+                        "primary-period": "tp",
+                        "primary-metric": "src::tst2",
+                        "status": "pass",
+                    },
+                },
+                {
+                    "run": {"id": "r1"},
+                    "iteration": {
+                        "id": "i3",
+                        "num": 3,
+                        "primary-period": "tp",
+                        "primary-metric": "src::tst1",
+                        "status": "fail",
+                    },
+                },
+            ],
+        )
+
+        if notag:
+            tags = []
+        else:
+            tags = [
+                {"run": {"id": "r1"}, "tag": {"name": "a", "val": 42}},
+                {"run": {"id": "r2"}, "tag": {"name": "a", "val": 42}},
+            ]
+        fake_crucible.elastic.set_query("tag", tags, repeat=2)
+
+        if noparam:
+            params = []
+        else:
+            params = [
+                {
+                    "run": {"id": "r1"},
+                    "iteration": {"id": "i1"},
+                    "param": {"arg": "b", "val": "cde"},
+                },
+                {
+                    "run": {"id": "r1"},
+                    "iteration": {"id": "i1"},
+                    "param": {"arg": "z", "val": "xyzzy"},
+                },
+                {
+                    "run": {"id": "r3"},
+                    "iteration": {"id": "i1"},
+                    "param": {"arg": "z", "val": "xyzzy"},
+                },
+                {
+                    "run": {"id": "r1"},
+                    "iteration": {"id": "i2"},
+                    "param": {"arg": "b", "val": "cde"},
+                },
+                {
+                    "run": {"id": "r1"},
+                    "iteration": {"id": "i2"},
+                    "param": {"arg": "x", "val": "plugh"},
+                },
+            ]
+        fake_crucible.elastic.set_query("param", params, repeat=2)
+        expected = {
+            "count": 1,
+            "offset": 0,
+            "results": [
+                {
+                    "begin": "0",
+                    "begin_date": "1970-01-01 00:00:00+00:00",
+                    "benchmark": "test",
+                    "end": "5000",
+                    "end_date": "1970-01-01 00:00:05+00:00",
+                    "id": "r1",
+                    "iterations": [
+                        {
+                            "iteration": 1,
+                            "params": defaultdict(
+                                None,
+                                {
+                                    "b": "cde",
+                                    "z": "xyzzy",
+                                },
+                            ),
+                            "primary_metric": "src::tst1",
+                            "primary_period": "tp",
+                            "status": "pass",
+                        },
+                        {
+                            "iteration": 2,
+                            "params": defaultdict(
+                                None,
+                                {
+                                    "b": "cde",
+                                    "x": "plugh",
+                                },
+                            ),
+                            "primary_metric": "src::tst2",
+                            "primary_period": "tp",
+                            "status": "pass",
+                        },
+                        {
+                            "iteration": 3,
+                            "params": {},
+                            "primary_metric": "src::tst1",
+                            "primary_period": "tp",
+                            "status": "fail",
+                        },
+                    ],
+                    "params": {},
+                    "primary_metrics": {"src::tst1", "src::tst2"},
+                    "status": "fail",
+                    "tags": defaultdict(None, {"a": 42}),
+                },
+            ],
+            "sort": [],
+            "total": 1,
+        }
+        if notag or noparam:
+            expected["results"] = []
+            expected["count"] = 0
+            expected["total"] = 0
+        else:
+            if miss:
+                expected["total"] = 3
+        if "size" in args:
+            expected["size"] = args["size"]
+        if args.get("offset"):
+            expected["offset"] = args["offset"]
+        if args.get("start"):
+            expected["startDate"] = (
+                datetime.fromisoformat(args["start"])
+                .astimezone(tz=timezone.utc)
+                .isoformat()
+            )
+        if args.get("end"):
+            expected["endDate"] = (
+                datetime.fromisoformat(args["end"])
+                .astimezone(tz=timezone.utc)
+                .isoformat()
+            )
+        if args.get("sort"):
+            expected["sort"] = args["sort"]
+        assert expected == await fake_crucible.get_runs(**args)
+
+    async def test_get_tags(self, fake_crucible: CrucibleService):
+        """Get tags for a run ID"""
+        fake_crucible.elastic.set_query(
+            "tag",
+            [
+                {"run": {"id": "one"}, "tag": {"name": "a", "val": 123}},
+                {"run": {"id": "one"}, "tag": {"name": "b", "val": "hello"}},
+                {"run": {"id": "one"}, "tag": {"name": "c", "val": False}},
+            ],
+        )
+        assert {"a": 123, "b": "hello", "c": False} == await fake_crucible.get_tags(
+            "one"
+        )
+
+    async def test_get_params_none(self, fake_crucible: CrucibleService):
+        """Test error when neither run nor iteration is specified"""
+        with pytest.raises(HTTPException) as exc:
+            await fake_crucible.get_params()
+        assert 400 == exc.value.status_code
+        assert (
+            "A params query requires either a run or iteration ID" == exc.value.detail
+        )
+
+    async def test_get_params_run(self, fake_crucible: CrucibleService):
+        """Get parameters for a run"""
+        params = [
+            {
+                "run": {"id": "rid"},
+                "iteration": {"id": "iid1"},
+                "param": {"arg": "a", "val": 10},
+            },
+            {
+                "run": {"id": "rid"},
+                "iteration": {"id": "iid1"},
+                "param": {"arg": "b", "val": 5},
+            },
+            {
+                "run": {"id": "rid"},
+                "iteration": {"id": "iid1"},
+                "param": {"arg": "c", "val": "val"},
+            },
+            {
+                "run": {"id": "rid"},
+                "iteration": {"id": "iid2"},
+                "param": {"arg": "a", "val": 7},
+            },
+            {
+                "run": {"id": "rid"},
+                "iteration": {"id": "iid2"},
+                "param": {"arg": "c", "val": "val"},
+            },
+        ]
+        fake_crucible.elastic.set_query("param", params)
+        assert {
+            "common": {"c": "val"},
+            "iid1": {"a": 10, "b": 5, "c": "val"},
+            "iid2": {"a": 7, "c": "val"},
+        } == await fake_crucible.get_params("rid")
+
+    async def test_get_params_iteration(self, fake_crucible: CrucibleService):
+        """Get parameters for an iteration"""
+        params = [
+            {
+                "run": {"id": "rid"},
+                "iteration": {"id": "iid1"},
+                "param": {"arg": "a", "val": 10},
+            },
+            {
+                "run": {"id": "rid"},
+                "iteration": {"id": "iid1"},
+                "param": {"arg": "b", "val": 5},
+            },
+            {
+                "run": {"id": "rid"},
+                "iteration": {"id": "iid1"},
+                "param": {"arg": "c", "val": "val"},
+            },
+        ]
+        fake_crucible.elastic.set_query("param", params)
+        assert {
+            "iid1": {"a": 10, "b": 5, "c": "val"}
+        } == await fake_crucible.get_params(None, "iid1")
+
+    async def test_get_params_iteration_dup(self, fake_crucible: CrucibleService):
+        """Cover an obscure log warning case"""
+        params = [
+            {
+                "run": {"id": "rid"},
+                "iteration": {"id": "iid1"},
+                "param": {"arg": "a", "val": 10},
+            },
+            {
+                "run": {"id": "rid"},
+                "iteration": {"id": "iid1"},
+                "param": {"arg": "a", "val": 5},
+            },
+        ]
+        fake_crucible.elastic.set_query("param", params)
+        assert {"iid1": {"a": 5}} == await fake_crucible.get_params(None, "iid1")
+
+    async def test_get_iterations(self, fake_crucible: CrucibleService):
+        """Get iterations for a run ID"""
+        iterations = [
+            {
+                "id": "one",
+                "num": 1,
+                "path": None,
+                "primary_metric": "test::metric1",
+                "primary_period": "measurement",
+                "status": "pass",
+            },
+            {
+                "id": "two",
+                "num": 2,
+                "path": None,
+                "primary_metric": "test::metric2",
+                "primary_period": "measurement",
+                "status": "pass",
+            },
+            {
+                "id": "three",
+                "num": 3,
+                "path": None,
+                "primary_metric": "test::metric1",
+                "primary_period": "measurement",
+                "status": "pass",
+            },
+        ]
+        fake_crucible.elastic.set_query(
+            "iteration",
+            [
+                {
+                    "run": {"id": "one"},
+                    "iteration": i,
+                }
+                for i in iterations
+            ],
+        )
+        assert iterations == await fake_crucible.get_iterations("one")
+
+    async def test_get_samples_none(self, fake_crucible: CrucibleService):
+        """Test error when neither run nor iteration is specified"""
+        with pytest.raises(HTTPException) as exc:
+            await fake_crucible.get_samples()
+        assert 400 == exc.value.status_code
+        assert (
+            "A sample query requires either a run or iteration ID" == exc.value.detail
+        )
+
+    @pytest.mark.parametrize("ids", (("one", None), (None, 1)))
+    async def test_get_samples(self, fake_crucible: CrucibleService, ids):
+        """Get samples for a run ID"""
+        samples = [
+            {
+                "num": "1",
+                "path": None,
+                "id": "one",
+                "status": "pass",
+                "primary_metric": "pm",
+                "primary_period": "m",
+                "iteration": 1,
+            },
+            {
+                "id": "two",
+                "num": "2",
+                "path": None,
+                "status": "pass",
+                "primary_metric": "pm",
+                "primary_period": "m",
+                "iteration": 1,
+            },
+            {
+                "id": "three",
+                "num": "3",
+                "path": None,
+                "status": "pass",
+                "primary_metric": "pm",
+                "primary_period": "m",
+                "iteration": 1,
+            },
+        ]
+        fake_crucible.elastic.set_query(
+            "sample",
+            [
+                {
+                    "run": {"id": "one"},
+                    "iteration": {
+                        "primary-metric": "pm",
+                        "primary-period": "m",
+                        "num": 1,
+                    },
+                    "sample": s,
+                }
+                for s in samples
+            ],
+        )
+        assert samples == await fake_crucible.get_samples(*ids)
+
+    async def test_get_periods_none(self, fake_crucible: CrucibleService):
+        """Test error when neither run, iteration, nor sample is specified"""
+        with pytest.raises(HTTPException) as exc:
+            await fake_crucible.get_periods()
+        assert 400 == exc.value.status_code
+        assert (
+            "A period query requires a run, iteration, or sample ID" == exc.value.detail
+        )
+
+    @pytest.mark.parametrize(
+        "ids", (("one", None, None), (None, 1, None), (None, None, 1))
+    )
+    async def test_get_periods(self, fake_crucible: CrucibleService, ids):
+        """Get samples for a run ID"""
+        periods = [
+            {
+                "begin": "2024-12-05 21:16:31.046000+00:00",
+                "end": "2024-12-05 21:40:31.166000+00:00",
+                "id": "306C8A78-B352-11EF-8E37-AD212D0A0B9F",
+                "name": "measurement",
+                "iteration": 1,
+                "sample": 1,
+                "primary_metric": "ilab::sdg-samples-sec",
+                "status": "pass",
+            }
+        ]
+        fake_crucible.elastic.set_query(
+            "period",
+            [
+                {
+                    "run": {"id": "one"},
+                    "iteration": {
+                        "primary-metric": p["primary_metric"],
+                        "primary-period": "measurement",
+                        "num": 1,
+                        "status": p["status"],
+                    },
+                    "sample": {"num": 1, "status": p["status"], "path": None},
+                    "period": {
+                        "id": p["id"],
+                        "name": p["name"],
+                        "begin": str(
+                            int(datetime.fromisoformat(p["begin"]).timestamp() * 1000)
+                        ),
+                        "end": str(
+                            int(datetime.fromisoformat(p["end"]).timestamp() * 1000)
+                        ),
+                        "primary-metric": p["primary_metric"],
+                        "status": p["status"],
+                    },
+                }
+                for p in periods
+            ],
+        )
+        assert periods == await fake_crucible.get_periods(*ids)
+
+    async def test_get_metrics_list(self, fake_crucible: CrucibleService):
+        """Get samples for a run ID"""
+        metrics = {
+            "source1::type1": {
+                "periods": [],
+                "breakouts": {"name1": ["value1", "value2"]},
+            },
+            "source1::type2": {"periods": ["p1", "p2"], "breakouts": {}},
+        }
+        query = [
+            {
+                "run": {"id": "one"},
+                "metric_desc": {
+                    "source": "source1",
+                    "type": "type1",
+                    "names": {"name1": "value1"},
+                },
+            },
+            {
+                "run": {"id": "one"},
+                "metric_desc": {
+                    "source": "source1",
+                    "type": "type1",
+                    "names": {"name1": "value1"},
+                },
+            },
+            {
+                "run": {"id": "one"},
+                "metric_desc": {
+                    "source": "source1",
+                    "type": "type1",
+                    "names": {"name1": "value2"},
+                },
+            },
+            {
+                "run": {"id": "one"},
+                "metric_desc": {
+                    "source": "source1",
+                    "type": "type1",
+                    "names": {"name1": "value2"},
+                },
+            },
+            {
+                "run": {"id": "one"},
+                "period": {"id": "p1"},
+                "metric_desc": {"source": "source1", "type": "type2", "names": {}},
+            },
+            {
+                "run": {"id": "one"},
+                "period": {"id": "p2"},
+                "metric_desc": {"source": "source1", "type": "type2", "names": {}},
+            },
+        ]
+        fake_crucible.elastic.set_query("metric_desc", query)
+        result = await fake_crucible.get_metrics_list("one")
+
+        # NOTE: the method returns a defaultdict, which doesn't compare to a
+        # dict but "in the real world" serializes the same: so we just
+        # serialize and deserialize to mimic the actual API behavior.
+        result = json.loads(json.dumps(result))
+        assert metrics == result
+
+    async def test_get_metric_breakout_none(self, fake_crucible: CrucibleService):
+        """Test error when the metric isn't found"""
+        fake_crucible.elastic.set_query("metric_desc", [])
+        with pytest.raises(HTTPException) as exc:
+            await fake_crucible.get_metric_breakouts(
+                "one", metric="source1::type1", names=[], periods=[]
+            )
+        assert 400 == exc.value.status_code
+        assert "Metric name source1::type1 not found for run one" == exc.value.detail
+
+    @pytest.mark.parametrize("period", (True, False))
+    async def test_get_metric_breakout(self, period, fake_crucible: CrucibleService):
+        """Get samples for a run ID"""
+        metrics = {
+            "label": "source1::type1",
+            "class": ["classless", "classy"],
+            "type": "type1",
+            "source": "source1",
+            "breakouts": {"name1": ["value1", "value2"]},
+        }
+        md1 = {
+            "run": {"id": "one"},
+            "metric_desc": {
+                "source": "source1",
+                "type": "type1",
+                "class": "classy",
+                "names": {"name1": "value1"},
+            },
+        }
+        md2 = {
+            "run": {"id": "one"},
+            "metric_desc": {
+                "source": "source1",
+                "type": "type1",
+                "names": {"name1": "value2"},
+            },
+        }
+        if period:
+            metrics["periods"] = ["p1", "p2"]
+            md1["period"] = {"id": "p1"}
+            md2["period"] = {"id": "p2"}
+        query = [
+            md1,
+            md2,
+            {
+                "run": {"id": "one"},
+                "metric_desc": {
+                    "source": "source1",
+                    "type": "type1",
+                    "class": "classless",
+                    "names": {"name1": "value1"},
+                },
+            },
+            {
+                "run": {"id": "one"},
+                "metric_desc": {
+                    "source": "source1",
+                    "type": "type1",
+                    "names": {"name1": "value2"},
+                },
+            },
+        ]
+        fake_crucible.elastic.set_query("metric_desc", query)
+        result = await fake_crucible.get_metric_breakouts(
+            "one", metric="source1::type1", names=[], periods=[]
+        )
+
+        # NOTE: the method returns a defaultdict, which doesn't compare to a
+        # dict but "in the real world" serializes the same: so we just
+        # serialize and deserialize to mimic the actual API behavior.
+        result = json.loads(json.dumps(result))
+        assert metrics == result
+
+    async def test_metrics_data_one_noagg(self, fake_crucible: CrucibleService):
+        """Return data samples for a single metric"""
+
+        fake_crucible.elastic.set_query(
+            "metric_desc",
+            [{"metric_desc": {"id": "one-metric", "names": {}}}],
+        )
+        fake_crucible.elastic.set_query(
+            "metric_data",
+            [
+                {
+                    "metric_desc": {"id": "one-metric"},
+                    "metric_data": {
+                        "begin": "1726165775123",
+                        "end": "1726165789213",
+                        "duration": 14100,
+                        "value": 9.35271216694379,
+                    },
+                },
+                {
+                    "metric_desc": {"id": "one-metric"},
+                    "metric_data": {
+                        "begin": "1726165790000",
+                        "end": "1726165804022",
+                        "duration": 14022,
+                        "value": 9.405932330557683,
+                    },
+                },
+            ],
+        )
+        expected = [
+            {
+                "begin": "2024-09-12 18:29:35.123000+00:00",
+                "duration": 14.1,
+                "end": "2024-09-12 18:29:49.213000+00:00",
+                "value": 9.35271216694379,
+            },
+            {
+                "begin": "2024-09-12 18:29:50+00:00",
+                "duration": 14.022,
+                "end": "2024-09-12 18:30:04.022000+00:00",
+                "value": 9.405932330557683,
+            },
+        ]
+        assert expected == await fake_crucible.get_metrics_data("runid", "source::type")
+        assert fake_crucible.elastic.requests == [
+            Request(
+                "cdmv7dev-metric_desc",
+                {
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "run.id": "runid",
+                                    },
+                                },
+                                {
+                                    "term": {
+                                        "metric_desc.source": "source",
+                                    },
+                                },
+                                {
+                                    "term": {
+                                        "metric_desc.type": "type",
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    "size": 262144,
+                },
+                kwargs={"ignore_unavailable": True},
+            ),
+            Request(
+                "cdmv7dev-metric_data",
+                {
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "terms": {
+                                        "metric_desc.id": [
+                                            "one-metric",
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    "size": 262144,
+                },
+            ),
+        ]
+
+    @pytest.mark.parametrize("count", (0, 2))
+    async def test_metrics_data_agg(self, count, fake_crucible):
+        """Return data samples for aggregated metrics"""
+
+        fake_crucible.elastic.set_query(
+            "metric_desc",
+            [
+                {"metric_desc": {"id": "one-metric", "names": {}}},
+                {"metric_desc": {"id": "two-metric", "names": {}}},
+            ],
+        )
+        fake_crucible.elastic.set_query(
+            "metric_data",
+            aggregations={
+                "duration": {
+                    "count": count,
+                    "min": 14022,
+                    "max": 14100,
+                    "avg": 14061,
+                    "sum": 28122,
+                }
+            },
+        )
+        if count:
+            fake_crucible.elastic.set_query(
+                "metric_data",
+                aggregations={
+                    "interval": [
+                        {"key": 1726165789213, "value": {"value": 9.35271216694379}},
+                        {"key": 1726165804022, "value": {"value": 9.405932330557683}},
+                    ]
+                },
+            )
+            expected = [
+                {
+                    "begin": "2024-09-12 18:29:35.191000+00:00",
+                    "duration": 14.022,
+                    "end": "2024-09-12 18:29:49.213000+00:00",
+                    "value": 9.35271216694379,
+                },
+                {
+                    "begin": "2024-09-12 18:29:50+00:00",
+                    "duration": 14.022,
+                    "end": "2024-09-12 18:30:04.022000+00:00",
+                    "value": 9.405932330557683,
+                },
+            ]
+        else:
+            expected = []
+        assert expected == await fake_crucible.get_metrics_data(
+            "r1", "source::type", aggregate=True
+        )
+        expected_requests = [
+            Request(
+                "cdmv7dev-metric_desc",
+                {
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "run.id": "r1",
+                                    },
+                                },
+                                {
+                                    "term": {
+                                        "metric_desc.source": "source",
+                                    },
+                                },
+                                {
+                                    "term": {
+                                        "metric_desc.type": "type",
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    "size": 262144,
+                },
+                kwargs={"ignore_unavailable": True},
+            ),
+            Request(
+                "cdmv7dev-metric_data",
+                {
+                    "aggs": {
+                        "duration": {
+                            "stats": {
+                                "field": "metric_data.duration",
+                            },
+                        },
+                    },
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "terms": {
+                                        "metric_desc.id": [
+                                            "one-metric",
+                                            "two-metric",
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    "size": 0,
+                },
+            ),
+        ]
+        if count:
+            expected_requests.append(
+                Request(
+                    "cdmv7dev-metric_data",
+                    {
+                        "aggs": {
+                            "interval": {
+                                "aggs": {
+                                    "value": {
+                                        "sum": {
+                                            "field": "metric_data.value",
+                                        },
+                                    },
+                                },
+                                "histogram": {
+                                    "field": "metric_data.end",
+                                    "interval": 14022,
+                                },
+                            },
+                        },
+                        "query": {
+                            "bool": {
+                                "filter": [
+                                    {
+                                        "terms": {
+                                            "metric_desc.id": [
+                                                "one-metric",
+                                                "two-metric",
+                                            ],
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                        "size": 0,
+                    },
+                ),
+            )
+        assert fake_crucible.elastic.requests == expected_requests
+
+    async def test_metrics_summary(self, fake_crucible: CrucibleService):
+        """Return data summary for a metrics"""
+
+        fake_crucible.elastic.set_query(
+            "metric_desc",
+            [
+                {"metric_desc": {"id": "one-metric", "names": {"a": "1"}}},
+            ],
+        )
+        expected = {
+            "count": 5,
+            "min": 9.35271216694379,
+            "max": 9.405932330557683,
+            "avg": 9.379322249,
+            "sum": 18.758644498,
+        }
+        fake_crucible.elastic.set_query("metric_data", aggregations={"score": expected})
+        assert expected == await fake_crucible.get_metrics_summary(
+            "runid", "one-metric::type", ["a=1"]
+        )
+        assert fake_crucible.elastic.requests == [
+            Request(
+                "cdmv7dev-metric_desc",
+                {
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "run.id": "runid",
+                                    },
+                                },
+                                {
+                                    "term": {
+                                        "metric_desc.source": "one-metric",
+                                    },
+                                },
+                                {
+                                    "term": {
+                                        "metric_desc.type": "type",
+                                    },
+                                },
+                                {"term": {"metric_desc.names.a": "1"}},
+                            ],
+                        },
+                    },
+                    "size": 262144,
+                },
+                kwargs={"ignore_unavailable": True},
+            ),
+            Request(
+                "cdmv7dev-metric_data",
+                {
+                    "aggs": {"score": {"stats": {"field": "metric_data.value"}}},
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "terms": {
+                                        "metric_desc.id": [
+                                            "one-metric",
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    "size": 0,
+                },
+            ),
+        ]
+
+    @pytest.mark.parametrize(
+        "runs,param_idx,periods,period_idx,title",
+        (
+            ([], 0, [], 0, "source::type"),
+            (["r2", "r1"], 0, [], 0, "source::type {run 2}"),
+            ([], 0, ["p1"], 0, "source::type (n=42)"),
+            ([], 1, ["p1"], 1, "source::type"),
+            ([], 1, ["p1"], 2, "source::type"),
+        ),
+    )
+    async def test_graph_title_no_query(
+        self,
+        runs,
+        param_idx,
+        periods,
+        period_idx,
+        title,
+        fake_crucible: CrucibleService,
+    ):
+        """Test generation of default metric titles"""
+
+        param_runs = [
+            {"r1": {"i1": {"n": "42"}, "i2": {"n": "31"}}},
+            {"r1": {"i1": {"n": "42"}, "i2": {"n": "42"}}},
+        ][param_idx]
+        period_runs = [
+            {"r1": {"i1": {"p1"}, "i2": {"p2"}}},
+            {"r1": {"i1": {"p1"}}},
+            {"r1": {"i1": {"p2"}}},
+        ][period_idx]
+        name = await fake_crucible._graph_title(
+            "r1",
+            runs,
+            Graph(metric="source::type", periods=periods),
+            param_runs,
+            period_runs,
+        )
+        assert name == title
+
+    async def test_graph_title_query(self, fake_crucible: CrucibleService):
+        """Test generation of default metric titles"""
+
+        param_runs = {}
+        period_runs = {}
+        fake_crucible.elastic.set_query(
+            "param",
+            [
+                {
+                    "run": {"id": "r1"},
+                    "iteration": {"id": "i1"},
+                    "param": {"arg": "a", "val": "1"},
+                },
+            ],
+        )
+        fake_crucible.elastic.set_query(
+            "period",
+            [
+                {
+                    "run": {"id": "r1"},
+                    "iteration": {"id": "i1"},
+                    "period": {"id": "p1"},
+                },
+            ],
+        )
+        name = await fake_crucible._graph_title(
+            "r1",
+            [],
+            Graph(metric="source::type"),
+            param_runs,
+            period_runs,
+        )
+        assert name == "source::type"
+        assert fake_crucible.elastic.requests == [
+            Request(
+                "cdmv7dev-param",
+                {
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "run.id": "r1",
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    "size": 262144,
+                },
+            ),
+            Request(
+                "cdmv7dev-period",
+                {
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "run.id": "r1",
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    "size": 262144,
+                },
+            ),
+        ]
+
+    async def test_metrics_graph_norun(self, fake_crucible: CrucibleService):
+        with pytest.raises(HTTPException) as exc:
+            await fake_crucible.get_metrics_graph(
+                GraphList(
+                    name="graph",
+                    graphs=[Graph(metric="source::type", aggregate=True, title="test")],
+                )
+            )
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "each graph request must have a run ID"
+
+    @pytest.mark.parametrize("count", (0, 2))
+    async def test_metrics_graph(self, count, fake_crucible: CrucibleService):
+        """Return graph for aggregated metrics"""
+
+        metrics = [{"metric_desc": {"id": "one-metric", "names": {}}}]
+        if count:
+            metrics.append({"metric_desc": {"id": "two-metric", "names": {}}})
+            fake_crucible.elastic.set_query(
+                "metric_data",
+                aggregations={
+                    "duration": {
+                        "count": count,
+                        "min": 14022,
+                        "max": 14100,
+                        "avg": 14061,
+                        "sum": 28122,
+                    }
+                },
+            )
+            fake_crucible.elastic.set_query(
+                "metric_data",
+                aggregations={
+                    "interval": [
+                        {"key": 1726165789213, "value": {"value": 9.35271216694379}},
+                        {"key": 1726165804022, "value": {"value": 9.405932330557683}},
+                    ]
+                },
+            )
+            expected = {
+                "data": [
+                    {
+                        "labels": {
+                            "x": "sample timestamp",
+                            "y": "samples / second",
+                        },
+                        "marker": {
+                            "color": "black",
+                        },
+                        "mode": "line",
+                        "name": "test",
+                        "type": "scatter",
+                        "x": [
+                            "2024-09-12 18:29:49.213000+00:00",
+                            "2024-09-12 18:30:03.234000+00:00",
+                            "2024-09-12 18:30:04.022000+00:00",
+                            "2024-09-12 18:30:18.043000+00:00",
+                        ],
+                        "y": [
+                            9.35271216694379,
+                            9.35271216694379,
+                            9.405932330557683,
+                            9.405932330557683,
+                        ],
+                        "yaxis": "y",
+                    },
+                ],
+                "layout": {
+                    "width": "1500",
+                    "yaxis": {
+                        "color": "black",
+                        "title": "source::type",
+                    },
+                },
+            }
+        else:
+            expected = {
+                "data": [
+                    {
+                        "labels": {
+                            "x": "sample timestamp",
+                            "y": "samples / second",
+                        },
+                        "marker": {
+                            "color": "black",
+                        },
+                        "mode": "line",
+                        "name": "test",
+                        "type": "scatter",
+                        "x": [
+                            "2024-09-12 18:29:49.213000+00:00",
+                            "2024-09-12 18:29:50.213000+00:00",
+                            "2024-09-12 18:30:04.022000+00:00",
+                            "2024-09-12 18:30:05.022000+00:00",
+                        ],
+                        "y": [
+                            9.35271216694379,
+                            9.35271216694379,
+                            9.405932330557683,
+                            9.405932330557683,
+                        ],
+                        "yaxis": "y",
+                    },
+                ],
+                "layout": {
+                    "width": "1500",
+                    "yaxis": {
+                        "color": "black",
+                        "title": "source::type",
+                    },
+                },
+            }
+            fake_crucible.elastic.set_query(
+                "metric_data",
+                [
+                    {
+                        "metric_data": {
+                            "begin": "1726165789213",
+                            "end": "1726165790213",
+                            "value": 9.35271216694379,
+                        }
+                    },
+                    {
+                        "metric_data": {
+                            "begin": "1726165804022",
+                            "end": "1726165805022",
+                            "value": 9.405932330557683,
+                        }
+                    },
+                ],
+            )
+        fake_crucible.elastic.set_query("metric_desc", metrics)
+
+        assert expected == await fake_crucible.get_metrics_graph(
+            GraphList(
+                run="r1",
+                name="graph",
+                graphs=[Graph(metric="source::type", aggregate=True, title="test")],
+            )
+        )
+        expected_requests = [
+            Request(
+                "cdmv7dev-metric_desc",
+                {
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "run.id": "r1",
+                                    },
+                                },
+                                {
+                                    "term": {
+                                        "metric_desc.source": "source",
+                                    },
+                                },
+                                {
+                                    "term": {
+                                        "metric_desc.type": "type",
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    "size": 262144,
+                },
+                kwargs={"ignore_unavailable": True},
+            ),
+        ]
+        if count:
+            expected_requests.extend(
+                [
+                    Request(
+                        "cdmv7dev-metric_data",
+                        {
+                            "aggs": {
+                                "duration": {
+                                    "stats": {
+                                        "field": "metric_data.duration",
+                                    },
+                                },
+                            },
+                            "query": {
+                                "bool": {
+                                    "filter": [
+                                        {
+                                            "terms": {
+                                                "metric_desc.id": [
+                                                    "one-metric",
+                                                    "two-metric",
+                                                ],
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                            "size": 0,
+                        },
+                    ),
+                    Request(
+                        "cdmv7dev-metric_data",
+                        {
+                            "aggs": {
+                                "interval": {
+                                    "aggs": {
+                                        "value": {
+                                            "sum": {
+                                                "field": "metric_data.value",
+                                            },
+                                        },
+                                    },
+                                    "histogram": {
+                                        "field": "metric_data.begin",
+                                        "interval": 14022,
+                                    },
+                                },
+                            },
+                            "query": {
+                                "bool": {
+                                    "filter": [
+                                        {
+                                            "terms": {
+                                                "metric_desc.id": [
+                                                    "one-metric",
+                                                    "two-metric",
+                                                ],
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                            "size": 0,
+                        },
+                    ),
+                ]
+            )
+        else:
+            expected_requests.append(
+                Request(
+                    "cdmv7dev-metric_data",
+                    {
+                        "query": {
+                            "bool": {
+                                "filter": [
+                                    {
+                                        "terms": {
+                                            "metric_desc.id": ["one-metric"],
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                        "size": 262144,
+                    },
+                ),
+            )
+        assert fake_crucible.elastic.requests == expected_requests


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`crucible_svc.py` test coverage is now at 97%. While the remaining 3% is worth some effort later, the law of diminishing returns will require A significant additional effort; and since subsequent ILAB PRs will change some of the service code anyway it's good enough for now.

## Related Tickets & Documents

[PANDA-678](https://issues.redhat.com/browse/PANDA-678) crucible service unit test coverage

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
`tox -e unit -- -vv` (the `-- -vv` adds full diffs on failure for test debugging, and is optional)

Coverage is reported inline in text summary form, and also generates a detailed HTML report in the local `/var/tmp/${USER}/html/` which can be viewed in the browser to find holes. (The CI job saves the `html` report as an artifact, which can be downloaded from the [GitHub Action report](https://github.com/cloud-bulldozer/cpt-dashboard/actions/runs/14655769057/artifacts/3006686771).)