### PR TITLE
Containerfile Changes to address OpenShift SCC Deployment

### DIFF
--- a/backend/backend.containerfile
+++ b/backend/backend.containerfile
@@ -12,10 +12,10 @@ RUN dnf install -y python3-pip gcc python3-devel gcc-c++ && \
     poetry self add poetry-plugin-export && \
     dnf clean all
 
-# 2) Prepare world-writable dirs (for arbitrary UID)
-RUN mkdir -p /opt/backend && \
-    mkdir -p /opt/backend/.config/pypoetry && \
-    mkdir -p /opt/backend/.cache/pypoetry && \
+# 2) Prepare writable dirs
+#    Grant group rwx so both OpenShift’s random non-root UID (in GID=0) and
+#    Podman's default user, root, can write
+RUN mkdir -p /opt/backend /opt/backend/.config/pypoetry /opt/backend/.cache/pypoetry && \
     chmod -R g+rwX /opt/backend
 
 WORKDIR /opt/backend
@@ -24,10 +24,10 @@ EXPOSE 8000
 # 3) Copy manifest files & install Python deps
 COPY pyproject.toml poetry.lock version.json ./
 RUN poetry config virtualenvs.in-project true && \
-    poetry export --without-hashes -f requirements.txt -o requirements.txt && \
-    pip3 install --no-cache-dir -r requirements.txt && \
-    chmod -R g+rwX /opt/backend/.cache/pypoetry && \
-    chmod -R g+rwX /opt/backend/.config/pypoetry
+    poetry install --no-dev --no-interaction --no-ansi && \
+    # Ensure generated cache and config files are group-writable
+    # for both OpenShift (random UID in GID=0) and Podman (root) environments
+    chmod -R g+rwX /opt/backend/.cache/pypoetry /opt/backend/.config/pypoetry
 
 # 4) Copy application code and scripts
 COPY app/     ./app

--- a/backend/backend.containerfile
+++ b/backend/backend.containerfile
@@ -10,19 +10,24 @@ COPY app/ /backend/app
 COPY scripts/ /backend/scripts
 COPY pyproject.toml /backend
 COPY poetry.lock /backend
-COPY version.json /backend
+# COPY version.json /backend
 
 WORKDIR /backend
 
 EXPOSE 8000
 
-RUN dnf install -y pip gcc python3-devel gcc-c++
+RUN dnf install -y pip gcc python3-devel gcc-c++ git
 
 RUN pip install --user poetry && \
     poetry self add poetry-plugin-export && \
     poetry export --without-hashes -f requirements.txt -o requirements.txt && \
     pip install -U typing-extensions && \
     pip install --user dash && \
-    pip install --no-cache-dir -r requirements.txt
+    pip install --no-cache-dir -r requirements.txt && \
+    ln -s ~/.local/bin/poetry /usr/local/bin/poetry 
+
+COPY version.json version.json
+
+WORKDIR /backend
 
 ENTRYPOINT ["/bin/bash", "./scripts/start.sh"]

--- a/backend/backend.containerfile
+++ b/backend/backend.containerfile
@@ -7,6 +7,8 @@ ENV POETRY_VIRTUALENVS_CREATE=false \
     XDG_CACHE_HOME=/opt/backend/.cache
 
 # 1) Install system deps + Poetry globally (root)
+#    Installing Poetry globally ensures the binary is on /usr/local/bin
+#    and therefore available in both OpenShift (random UID) and Podman (root) environments
 RUN dnf install -y python3-pip gcc python3-devel gcc-c++ && \
     pip3 install --no-cache-dir poetry && \
     poetry self add poetry-plugin-export && \
@@ -21,17 +23,16 @@ RUN mkdir -p /opt/backend /opt/backend/.config/pypoetry /opt/backend/.cache/pypo
 WORKDIR /opt/backend
 EXPOSE 8000
 
-# 3) Copy manifest files & install Python deps
+# 3) Copy manifest files & install Python deps via export
 COPY pyproject.toml poetry.lock version.json ./
-RUN poetry config virtualenvs.in-project true && \
-    poetry install --no-dev --no-interaction --no-ansi && \
+RUN poetry export --without-hashes -f requirements.txt -o requirements.txt && \
+    pip3 install --no-cache-dir -r requirements.txt && \
     # Ensure generated cache and config files are group-writable
-    # for both OpenShift (random UID in GID=0) and Podman (root) environments
+    # for both OpenShift (random UID in GID=0) and Podman (root) \
+    # environments
     chmod -R g+rwX /opt/backend/.cache/pypoetry /opt/backend/.config/pypoetry
 
-# 4) Copy application code and scripts
 COPY app/     ./app
 COPY scripts/ ./scripts
 
-# 5) Launch via your startup script
 ENTRYPOINT ["/bin/bash", "scripts/start.sh"]

--- a/backend/backend.containerfile
+++ b/backend/backend.containerfile
@@ -1,41 +1,37 @@
 FROM quay.io/centos/centos:stream9
 
-ENV PATH=/root/.local/bin:$PATH \
-    LANG=C.UTF-8 \
-    PYTHONPATH=/backend \
-    PATH=/usr/local/bin:$PATH 
+# 0) Configure Poetry and environment for OpenShift non-root execution
+ENV POETRY_VIRTUALENVS_CREATE=false \
+    HOME=/opt/backend \
+    XDG_CONFIG_HOME=/opt/backend/.config \
+    XDG_CACHE_HOME=/opt/backend/.cache
 
+# 1) Install system deps + Poetry globally (root)
+RUN dnf install -y python3-pip gcc python3-devel gcc-c++ && \
+    pip3 install --no-cache-dir poetry && \
+    poetry self add poetry-plugin-export && \
+    dnf clean all
 
-RUN useradd -m -d /home/appuser appuser && \
-    chmod 755 /home/appuser && \
-    mkdir /home/appuser/backend && \
-    chown appuser:appuser /home/appuser/backend && \
-    chmod 777 /home/appuser/backend
+# 2) Prepare world-writable dirs (for arbitrary UID)
+RUN mkdir -p /opt/backend && \
+    mkdir -p /opt/backend/.config/pypoetry && \
+    mkdir -p /opt/backend/.cache/pypoetry && \
+    chmod -R g+rwX /opt/backend
 
-
-
-COPY app/ /home/appuser/backend/app
-COPY scripts/ /home/appuser/backend/scripts
-COPY pyproject.toml /home/appuser/backend
-COPY poetry.lock /home/appuser/backend
-
-
-WORKDIR /home/appuser/backend
-
+WORKDIR /opt/backend
 EXPOSE 8000
 
-RUN dnf install -y pip gcc python3-devel gcc-c++ git
-
-RUN pip install poetry && \
-    poetry config virtualenvs.in-project true && \
-    poetry self add poetry-plugin-export && \
+# 3) Copy manifest files & install Python deps
+COPY pyproject.toml poetry.lock version.json ./
+RUN poetry config virtualenvs.in-project true && \
     poetry export --without-hashes -f requirements.txt -o requirements.txt && \
-    pip install -U typing-extensions && \
-    pip install --user dash && \
-    pip install --no-cache-dir -r requirements.txt 
+    pip3 install --no-cache-dir -r requirements.txt && \
+    chmod -R g+rwX /opt/backend/.cache/pypoetry && \
+    chmod -R g+rwX /opt/backend/.config/pypoetry
 
-COPY version.json version.json
+# 4) Copy application code and scripts
+COPY app/     ./app
+COPY scripts/ ./scripts
 
-WORKDIR /home/appuser/backend
-
-ENTRYPOINT ["/bin/bash", "./scripts/start.sh"]
+# 5) Launch via your startup script
+ENTRYPOINT ["/bin/bash", "scripts/start.sh"]

--- a/backend/backend.containerfile
+++ b/backend/backend.containerfile
@@ -21,7 +21,6 @@ RUN mkdir -p /opt/backend /opt/backend/.config/pypoetry /opt/backend/.cache/pypo
     chmod -R g+rwX /opt/backend
 
 WORKDIR /opt/backend
-EXPOSE 8000
 
 # 3) Copy manifest files & install Python deps via export
 COPY pyproject.toml poetry.lock version.json ./
@@ -35,4 +34,5 @@ RUN poetry export --without-hashes -f requirements.txt -o requirements.txt && \
 COPY app/     ./app
 COPY scripts/ ./scripts
 
+EXPOSE 8000
 ENTRYPOINT ["/bin/bash", "scripts/start.sh"]

--- a/backend/backend.containerfile
+++ b/backend/backend.containerfile
@@ -6,17 +6,18 @@ ENV PATH=/root/.local/bin:$PATH \
     PATH=/usr/local/bin:$PATH
 
 RUN useradd -m -d /home/appuser appuser && \
+    chmod 755 /home/appuser && \
     mkdir /home/appuser/backend && \
     chown appuser:appuser /home/appuser/backend && \
     chmod 777 /home/appuser/backend
 
-# RUN mkdir /backend
+
 
 COPY app/ /home/appuser/backend/app
 COPY scripts/ /home/appuser/backend/scripts
 COPY pyproject.toml /home/appuser/backend
 COPY poetry.lock /home/appuser/backend
-# COPY version.json /backend
+
 
 WORKDIR /home/appuser/backend
 

--- a/backend/backend.containerfile
+++ b/backend/backend.containerfile
@@ -27,7 +27,7 @@ COPY pyproject.toml poetry.lock version.json ./
 RUN poetry export --without-hashes -f requirements.txt -o requirements.txt && \
     pip3 install --no-cache-dir -r requirements.txt && \
     # Ensure generated cache and config files are group-writable
-    # for both OpenShift (random UID in GID=0) and Podman (root) \
+    # for both OpenShift (random UID in GID=0) and Podman (root) 
     # environments
     chmod -R g+rwX /opt/backend/.cache/pypoetry /opt/backend/.config/pypoetry
 

--- a/backend/backend.containerfile
+++ b/backend/backend.containerfile
@@ -2,32 +2,37 @@ FROM quay.io/centos/centos:stream9
 
 ENV PATH=/root/.local/bin:$PATH \
     LANG=C.UTF-8 \
-    PYTHONPATH=/backend
+    PYTHONPATH=/backend \
+    PATH=/usr/local/bin:$PATH
 
-RUN mkdir /backend
+RUN useradd -m -d /home/appuser appuser && \
+    mkdir /home/appuser/backend && \
+    chown appuser:appuser /home/appuser/backend && \
+    chmod 777 /home/appuser/backend
 
-COPY app/ /backend/app
-COPY scripts/ /backend/scripts
-COPY pyproject.toml /backend
-COPY poetry.lock /backend
+# RUN mkdir /backend
+
+COPY app/ /home/appuser/backend/app
+COPY scripts/ /home/appuser/backend/scripts
+COPY pyproject.toml /home/appuser/backend
+COPY poetry.lock /home/appuser/backend
 # COPY version.json /backend
 
-WORKDIR /backend
+WORKDIR /home/appuser/backend
 
 EXPOSE 8000
 
 RUN dnf install -y pip gcc python3-devel gcc-c++ git
 
-RUN pip install --user poetry && \
+RUN pip install poetry && \
     poetry self add poetry-plugin-export && \
     poetry export --without-hashes -f requirements.txt -o requirements.txt && \
     pip install -U typing-extensions && \
     pip install --user dash && \
-    pip install --no-cache-dir -r requirements.txt && \
-    ln -s ~/.local/bin/poetry /usr/local/bin/poetry 
+    pip install --no-cache-dir -r requirements.txt 
 
 COPY version.json version.json
 
-WORKDIR /backend
+WORKDIR /home/appuser/backend
 
 ENTRYPOINT ["/bin/bash", "./scripts/start.sh"]

--- a/backend/backend.containerfile
+++ b/backend/backend.containerfile
@@ -3,7 +3,8 @@ FROM quay.io/centos/centos:stream9
 ENV PATH=/root/.local/bin:$PATH \
     LANG=C.UTF-8 \
     PYTHONPATH=/backend \
-    PATH=/usr/local/bin:$PATH
+    PATH=/usr/local/bin:$PATH 
+
 
 RUN useradd -m -d /home/appuser appuser && \
     chmod 755 /home/appuser && \
@@ -26,6 +27,7 @@ EXPOSE 8000
 RUN dnf install -y pip gcc python3-devel gcc-c++ git
 
 RUN pip install poetry && \
+    poetry config virtualenvs.in-project true && \
     poetry self add poetry-plugin-export && \
     poetry export --without-hashes -f requirements.txt -o requirements.txt && \
     pip install -U typing-extensions && \

--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -20,16 +20,27 @@ spec:
       labels:
         {{- include "dashboard.selectorLabels" . | nindent 8 }}   
     spec:
-      {{- with .Values.initContainers }}
       initContainers:
-        {{- toYaml . | nident 8 }}
-      {{- end }}
+        - name: init-tmp
+          image: busybox
+          command: ["sh", "-c", "chmod 1777 /tmp"]
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp        
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          secret:
+            secretName: {{ .Values.elasticsearch.existingSecretName | default (printf "%s" (include "dashboard.fullname" .)) }}      
       containers:
         - name: frontend
           image: {{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}
@@ -58,10 +69,5 @@ spec:
             - name: config 
               mountPath: /backend/ocpperf.toml
               subPath: ocpperf.toml
-      volumes:
-        - name: tmp
-          emptyDir: {}
-        - name: config
-          secret:
-            secretName: {{ .Values.elasticsearch.existingSecretName | default (printf "%s" (include "dashboard.fullname" .)) }}
+
 

--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       {{- with .Values.initContainers }}
       initContainers:
-        {{- toYaml . | nident 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.volumes }}
       volumes:
@@ -45,6 +45,9 @@ spec:
             {{- toYaml .Values.frontend.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.frontend.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
         - name: backend
           image: {{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}
           imagePullPolicy: "Always"

--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -22,11 +22,7 @@ spec:
     spec:
       {{- with .Values.initContainers }}
       initContainers:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nident 8 }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -63,6 +59,8 @@ spec:
               mountPath: /backend/ocpperf.toml
               subPath: ocpperf.toml
       volumes:
+        - name: tmp
+          emptyDir: {}
         - name: config
           secret:
             secretName: {{ .Values.elasticsearch.existingSecretName | default (printf "%s" (include "dashboard.fullname" .)) }}

--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -20,15 +20,6 @@ spec:
       labels:
         {{- include "dashboard.selectorLabels" . | nindent 8 }}   
     spec:
-      initContainers:
-        - name: init-tmp
-          image: busybox
-          command: ["sh", "-c", "chmod 1777 /tmp"]
-          securityContext:
-            runAsUser: 0
-          volumeMounts:
-            - name: tmp
-              mountPath: /tmp        
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -27,8 +27,6 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
-        - name: tmp
-          emptyDir: {}
         - name: config
           secret:
             secretName: {{ .Values.elasticsearch.existingSecretName | default (printf "%s" (include "dashboard.fullname" .)) }}      
@@ -43,9 +41,6 @@ spec:
             {{- toYaml .Values.frontend.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.frontend.securityContext | nindent 12 }}
-          volumeMounts:
-            - name: tmp
-              mountPath: /tmp
         - name: backend
           image: {{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}
           imagePullPolicy: "Always"

--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -20,6 +20,14 @@ spec:
       labels:
         {{- include "dashboard.selectorLabels" . | nindent 8 }}   
     spec:
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nident 8 }}
+      {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -18,7 +18,6 @@ frontend:
     tag: latest
   resources: {}
 
-
 backend:
   image:
     repository: quay.io/mleader/backend

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -14,13 +14,13 @@ elasticsearch:
 
 frontend:
   image:
-    repository: quay.io/mleader/frontend
+    repository: quay.io/cloud-bulldozer/frontend
     tag: latest
   resources: {}
 
 backend:
   image:
-    repository: quay.io/mleader/backend
+    repository: quay.io/cloud-bulldozer/backend
     tag: latest
   resources: {}
   securityContext: {}

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -31,22 +31,3 @@ podAnnotations:
 
 podSecurityContext: {}
 
-volumes:
-  - name: tmp
-    emptyDir: {}
-
-initContainers:
-  - name: init-tmp
-    image: busybox
-    command: ["sh", "-c", "chmod 1777 /tmp"]
-    securityContext:
-      runAsUser: 0
-    volumeMounts:
-      - name: tmp
-        mountPath: /tmp
-
-containers:
-  - name: frontend
-    volumeMounts:
-      - name: tmp
-        mountPath: /tmp

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -29,12 +29,21 @@ backend:
 podAnnotations:
   alpha.image.policy.openshift.io/resolve-names: '*'
 
-podSecurityContext: 
-  fsGroup: 101
+podSecurityContext: {}
 
 volumes:
   - name: tmp
     emptyDir: {}
+
+initContainers:
+  - name: init-tmp
+    image: busybox
+    command: ["sh", "-c", "chmod 1777 /tmp"]
+    securityContext:
+      runAsUser: 0
+    volumeMounts:
+      - name: tmp
+        mountPath: /tmp
 
 containers:
   - name: frontend

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -14,7 +14,7 @@ elasticsearch:
 
 frontend:
   image:
-    repository: quay.io/cloud-bulldozer/frontend
+    repository: quay.io/mleader/frontend
     tag: latest
   resources: {}
 
@@ -29,6 +29,6 @@ backend:
 podAnnotations:
   alpha.image.policy.openshift.io/resolve-names: '*'
 
-podSecurityContext: 
-  fsGroup: 1000660000
+podSecurityContext: {}
+  # fsGroup: 1000660000
 

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -17,9 +17,7 @@ frontend:
     repository: quay.io/cloud-bulldozer/frontend
     tag: latest
   resources: {}
-  securityContext:
-    privileged: true
-    allowPrivilegeEscalation: true
+
 
 backend:
   image:
@@ -31,5 +29,15 @@ backend:
 podAnnotations:
   alpha.image.policy.openshift.io/resolve-names: '*'
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext: 
+  fsGroup: 101
+
+volumes:
+  - name: tmp
+    emptyDir: {}
+
+containers:
+  - name: frontend
+    volumeMounts:
+      - name: tmp
+        mountPath: /tmp

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -30,5 +30,5 @@ podAnnotations:
   alpha.image.policy.openshift.io/resolve-names: '*'
 
 podSecurityContext: 
-  fsGroup: 1000650000
+  fsGroup: 1000660000
 

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -29,5 +29,6 @@ backend:
 podAnnotations:
   alpha.image.policy.openshift.io/resolve-names: '*'
 
-podSecurityContext: {}
+podSecurityContext: 
+  fsGroup: 1000650000
 

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -30,5 +30,3 @@ podAnnotations:
   alpha.image.policy.openshift.io/resolve-names: '*'
 
 podSecurityContext: {}
-  # fsGroup: 1000660000
-

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -21,7 +21,7 @@ frontend:
 
 backend:
   image:
-    repository: quay.io/cloud-bulldozer/backend
+    repository: quay.io/mleader/backend
     tag: latest
   resources: {}
   securityContext: {}

--- a/frontend/frontend.containerfile
+++ b/frontend/frontend.containerfile
@@ -11,12 +11,29 @@ RUN npm clean-install
 RUN npm run build
 
 FROM nginxinc/nginx-unprivileged:1.27-alpine
-COPY --chown=nginx:nginx --from=builder /usr/src/cpt-dashboard/dist/ /usr/share/nginx/html/
-COPY --chown=nginx:nginx nginx.conf /etc/nginx/nginx.conf
-# RUN touch /tmp/nginx.pid 
+
+RUN \
+    # 1) remove any stale PID so NGINX can create a fresh one at startup \
+    rm -f /var/cache/nginx/nginx.pid && \
+    # 2) force the cache dir to be owned by nginx:root (GID 0) \
+    chown -R nginx:0 /var/cache/nginx && \
+    # 3) grant group-write so any UID in GID 0 can create/delete files \
+    chmod -R g+w /var/cache/nginx && \
+    # 4) setgid so new files inherit GID 0 (root) \
+    chmod g+s /var/cache/nginx
+
+USER root
+RUN touch /var/cache/nginx/nginx.pid && \
+  chown nginx:root /var/cache/nginx/nginx.pid && \
+  chmod 664 /var/cache/nginx/nginx.pid
 
 USER nginx
-RUN touch /var/cache/nginx/nginx.pid
+COPY --chown=nginx:root --from=builder /usr/src/cpt-dashboard/dist/ /usr/share/nginx/html/
+COPY --chown=nginx:root nginx.conf /etc/nginx/nginx.conf
+# RUN touch /tmp/nginx.pid 
+
+
+# RUN touch /var/cache/nginx/nginx.pid
 EXPOSE 3000
 
 ENTRYPOINT ["nginx"]

--- a/frontend/frontend.containerfile
+++ b/frontend/frontend.containerfile
@@ -13,9 +13,10 @@ RUN npm run build
 FROM nginxinc/nginx-unprivileged:1.27-alpine
 COPY --chown=nginx:nginx --from=builder /usr/src/cpt-dashboard/dist/ /usr/share/nginx/html/
 COPY --chown=nginx:nginx nginx.conf /etc/nginx/nginx.conf
-RUN touch /tmp/nginx.pid
+# RUN touch /tmp/nginx.pid 
 
 USER nginx
+RUN touch /var/cache/nginx/nginx.pid
 EXPOSE 3000
 
 ENTRYPOINT ["nginx"]

--- a/frontend/frontend.containerfile
+++ b/frontend/frontend.containerfile
@@ -1,40 +1,52 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Stage 1: build your React/Vite app
+# ─────────────────────────────────────────────────────────────────────────────
 FROM node:18-bookworm-slim AS builder
 
 WORKDIR /usr/src/cpt-dashboard
+
+# Install dependencies first so we can leverage Docker cache
+COPY package*.json ./
+RUN npm ci
+
+# Copy source and build
 COPY public/ public/
-COPY src/ src/
-COPY index.html index.html
-COPY vite.config.js vite.config.js
-COPY jsconfig.json jsconfig.json
-ADD package*.json ./
-RUN npm clean-install
+COPY src/    src/
+COPY index.html vite.config.js jsconfig.json ./
 RUN npm run build
 
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Stage 2: runtime with unprivileged NGINX
+# ─────────────────────────────────────────────────────────────────────────────
 FROM nginxinc/nginx-unprivileged:1.27-alpine
 
-RUN \
-    # 1) remove any stale PID so NGINX can create a fresh one at startup \
-    rm -f /var/cache/nginx/nginx.pid && \
-    # 2) force the cache dir to be owned by nginx:root (GID 0) \
-    chown -R nginx:0 /var/cache/nginx && \
-    # 3) grant group-write so any UID in GID 0 can create/delete files \
-    chmod -R g+w /var/cache/nginx && \
-    # 4) setgid so new files inherit GID 0 (root) \
-    chmod g+s /var/cache/nginx
-
+# 1) Become root so we can fix ownership and create the PID file
 USER root
-RUN touch /var/cache/nginx/nginx.pid && \
-  chown nginx:root /var/cache/nginx/nginx.pid && \
-  chmod 664 /var/cache/nginx/nginx.pid
 
-USER nginx
-COPY --chown=nginx:root --from=builder /usr/src/cpt-dashboard/dist/ /usr/share/nginx/html/
+RUN \
+  # On OpenShift’s Restricted SCC the container runs as an arbitrary UID in GID=0,  \
+  # and under Podman it runs as nginx UID=101—so ensure the cache dir and PID file \
+  # are owned by nginx user and root group with group-write/setgid for both cases. \
+  mkdir -p  /var/cache/nginx && \
+  chown -R nginx:root  /var/cache/nginx && \
+  chmod -R g+w  /var/cache/nginx && \
+  chmod g+s  /var/cache/nginx && \
+  \
+  # remove any stale PID and pre-create a group-writable PID file owned by nginx:root, \
+  # ensuring Podman’s nginx user and OpenShift’s arbitrary UID (in GID=0) can write \
+  rm -f  /var/cache/nginx/nginx.pid && \
+  touch  /var/cache/nginx/nginx.pid && \
+  chown nginx:root  /var/cache/nginx/nginx.pid && \
+  chmod u=rw,g=rw,o=r  /var/cache/nginx/nginx.pid
+
+# 2) Copy in your custom config and the built assets, with nginx ownership
 COPY --chown=nginx:root nginx.conf /etc/nginx/nginx.conf
-# RUN touch /tmp/nginx.pid 
+COPY --chown=nginx:root --from=builder /usr/src/cpt-dashboard/dist/ /usr/share/nginx/html/
 
+# 3) Drop back to the unprivileged user
+USER nginx
 
-# RUN touch /var/cache/nginx/nginx.pid
 EXPOSE 3000
-
 ENTRYPOINT ["nginx"]
 CMD ["-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,4 +1,4 @@
-pid /tmp/nginx.pid;
+pid /var/cache/nginx/nginx.pid;
 worker_processes  auto;
 error_log  /var/log/nginx/error.log notice;
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- [X] Removed `privileged` and `allowPrivilegeEscalation` from the `frontend` `securityContext` since the default OpenShift SCC will not allow pods to be deployed with them
- [X] Backend and frontend containerfiles file permissions and access adapted to facilitate OpenShift's random UID and root GID of the process executing our pods.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.

1. OpenShift Local on my machine
2. Make changes to `backend.containerfile` and `frontend.containerfile`
3. Build and push changes to `quay.io/mleader/backend` and `quay.io/mleader/frontend`, respectively
4. Update Helm chart to use the previously mentioned images in its deployment
5. Install OpenShift GitOps operator (includes ArgoCD)
6. Create `cpt-dashboard` namespace
7. Label `cpt-dashboard` namespace for ArgoCD management
8. Create backend secret containing `ocpperf.toml`
9. Get OpenShift GitOps initial admin password
10. Login to ArgoCD web GUI
11. Create cpt-dashboard application that deploys with Helm
12. ArgoCD SYNC the application
13. Wait for the lights to go green
14. Profit

- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
