### PR TITLE
Backend Containerfile Transitio to Only Use Poetry

### DIFF
--- a/backend/backend.containerfile
+++ b/backend/backend.containerfile
@@ -11,7 +11,6 @@ ENV POETRY_VIRTUALENVS_CREATE=false \
 #    and therefore available in both OpenShift (random UID) and Podman (root) environments
 RUN dnf install -y python3-pip gcc python3-devel gcc-c++ && \
     pip3 install --no-cache-dir poetry && \
-    poetry self add poetry-plugin-export && \
     dnf clean all
 
 # 2) Prepare writable dirs
@@ -24,8 +23,7 @@ WORKDIR ${HOME}
 
 # 3) Copy manifest files & install Python deps via export
 COPY pyproject.toml poetry.lock version.json ./
-RUN poetry export --without-hashes -f requirements.txt -o requirements.txt && \
-    pip3 install --no-cache-dir -r requirements.txt && \
+RUN poetry install --no-root --no-interaction --no-ansi && \
     # Ensure generated cache and config files are group-writable
     # for both OpenShift (random UID in GID=0) and Podman (root) 
     # environments
@@ -33,6 +31,9 @@ RUN poetry export --without-hashes -f requirements.txt -o requirements.txt && \
 
 COPY app/     ./app
 COPY scripts/ ./scripts
+
+# install project as a package
+RUN poetry install --no-interaction --no-ansi
 
 EXPOSE 8000
 ENTRYPOINT ["/bin/bash", "scripts/start.sh"]

--- a/backend/backend.containerfile
+++ b/backend/backend.containerfile
@@ -32,7 +32,7 @@ RUN poetry install --no-root --no-interaction --no-ansi && \
 COPY app/     ./app
 COPY scripts/ ./scripts
 
-# install project as a package
+# separate installation for project source code as a package
 RUN poetry install --no-interaction --no-ansi
 
 EXPOSE 8000


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Removed the `poetry export` to `requirements.txt`, and `pip install`, in favor of using just `poetry`. 
`poetry install --no-root` installs only the dependencies, and then `poetry install` installs the project source code as a package.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
