### PR TITLE
Improve functional test pod startup

### DIFF
--- a/backend/tests/functional/conftest.py
+++ b/backend/tests/functional/conftest.py
@@ -23,28 +23,66 @@ def server():
 
 @pytest.fixture(scope="session", autouse=True)
 def restore_snapshot():
+
+    def indices(db: Elasticsearch) -> set[str]:
+        r = db.indices.get("*")
+        cdm = {i for i in r.keys() if i.startswith("cdmv")}
+        return cdm
+
     ok = False
-    start = time.time()
     while not ok:
+        time.sleep(5)
         try:
+            start = time.time()
             db = Elasticsearch("http://localhost:9200")
-            db.cluster.health(wait_for_status="yellow")
+            db.cluster.health(wait_for_status="green")
             print(f"Opensearch claims ready after {time.time()-start:.3f} seconds")
-            r = db.indices.get("*")
-            cdm = {i for i in r.keys() if i.startswith("cdmv")}
-            if cdm:
-                print(f"CDM indices appear to be available: {','.join(cdm)}")
-            else:
-                # Opensearch hasn't been loaded yet, so restore the snapshot
-                print("Restoring 'base' snapshot...")
-                r = db.snapshot.create_repository(repository="functional", body={"type": "fs", "settings": {"location": "/var/tmp/snapshot"}})
-                assert r.get("acknowledged") is True
-                r = db.snapshot.get(repository="functional", snapshot="base")
-                # We expect one snapshot, named "base"
-                assert r["snapshots"][0]["snapshot"] == "base"
-                r = db.snapshot.restore(repository="functional", snapshot="base", body={"indices": "cdmv*dev-*"}, wait_for_completion=True)
-                assert r["snapshot"]["shards"]["failed"] == 0
             ok = True
         except Exception as exc:
-            print(f"Opensearch isn't ready: {str(exc)!r}")
-            time.sleep(5)
+            print(f"Opensearch isn't ready: {type(exc).__name__} ({str(exc)!r})")
+            continue
+
+        r = db.indices.get("*")
+        cdm = indices(db)
+        if not cdm:
+            try:
+                # Opensearch hasn't been loaded yet, so restore the snapshot
+                print("Restoring 'base' snapshot...")
+                r = db.snapshot.create_repository(
+                    repository="functional",
+                    body={
+                        "type": "fs",
+                        "settings": {"location": "/var/tmp/snapshot"},
+                    },
+                )
+                assert (
+                    r.get("acknowledged") is True
+                ), f"Opensearch didn't create the repository: {r}"
+                r = db.snapshot.get(repository="functional", snapshot="base")
+                # We expect one snapshot, named "base"
+                assert (
+                    r["snapshots"][0]["snapshot"] == "base"
+                ), f"Opensearch didn't find our snapshot: {r}"
+                r = db.snapshot.restore(
+                    repository="functional",
+                    snapshot="base",
+                    request_timeout=20,
+                    body={"indices": "cdmv*dev-*"},
+                    wait_for_completion=True,
+                    master_timeout="60s",
+                )
+                assert (
+                    r["snapshot"]["shards"]["failed"] == 0
+                ), f"Opensearch restore failed: {r}"
+                cdm = indices(db)
+            except Exception as exc:
+                print(
+                    f"Opensearch restore problem: {type(exc).__name__} ({str(exc)!r})"
+                )
+                raise
+        print(f"Restored {len(cdm)} indices: {','.join(cdm)}")
+        time.sleep(2)  # Paranoia: allow stabilization
+        hits = db.search(index="cdmv7dev-run")
+        ids = [h["_source"]["run"]["id"] for h in hits["hits"]["hits"]]
+        print(f"Found run IDs {ids} ({len(ids)})")
+        assert len(ids) == 5, "Expected CDM run documents are missing"


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Try to reduce startup failures in the backend functional test Opensearch configuration with a more structured and resilient sequence to synchronize with the Opensearch container and restore the test data snapshot.

## Related Tickets & Documents

[PANDA-878](https://issues.redhat.com/browse/PANDA-878) improve functional test setup

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

Tested repeatedly locally. Unfortunately the occasional Opensearch connection error is very difficult to reproduce -- but while trying I found several weaknesses in the setup code that I hope I've mitigated.
