### PR TITLE
ILAB date picker updates when no ILAB jobs found

### DIFF
--- a/frontend/src/actions/ilabActions.js
+++ b/frontend/src/actions/ilabActions.js
@@ -24,7 +24,7 @@ export const fetchIlabJobs =
           ...(offset && { offset }),
         },
       });
-      if (response.status === 200 && response?.data?.results.length > 0) {
+      if (response.status === 200) {
         const startDate = response.data.startDate,
           endDate = response.data.endDate;
         dispatch({


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The `fetchILabJobs` action wasn't updating the date picker values from the API response unless a non-empty list of jobs is returned. This means that on the initial load, if the default API date range (1 month) doesn't find any jobs, the displayed list is empty and the date range isn't updated to tell the user what we've done.

I've seen no ill effects in local testing from simply removing the length check, and now the date picker is updated correctly.
## Related Tickets & Documents

[PANDA-858](https://issues.redhat.com/browse/PANDA-858) small date picker fix

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

Ran local UI functional & unit tests
