### PR TITLE
Improve formatting of delta time in ILAB comparison graph

### DIFF
--- a/backend/app/services/crucible_svc.py
+++ b/backend/app/services/crucible_svc.py
@@ -68,16 +68,24 @@ class GraphList(BaseModel):
     Normally the X axis will be the actual sample timestamp values; if you
     specify relative=True, the X axis will be the duration from the first
     timestamp of the metric series. This allows graphs of similar runs started
-    at different times to be overlaid.
+    at different times to be overlaid. Plotly (along with other plotting
+    packages like PatternFly's Victory) doesn't support a "delta time" axis
+    unit, so also specifying absolute_relative will report relative times as
+    small absolute times (e.g., "1970-01-01 00:00:01" for 1 second) and a
+    "tick format" of "%H:%M:%S", which will look nice on the graph as long as
+    the total duration doesn't reach 24 hours. Without absolute_relative, the
+    duration is reported as numeric (floating point) seconds.
 
     Fields:
         name: Specify a name for the set of graphs
         relative: True for relative timescale
+        absolute_relative: True to report relative timestamps as absolute
         graphs: a list of Graph objects
     """
 
     name: str
     relative: bool = False
+    absolute_relative: bool = False
     graphs: list[Metric]
 
 
@@ -1861,7 +1869,42 @@ class CrucibleService:
         """
         start = time.time()
         graphlist = []
-        layout: dict[str, Any] = {"width": "1500"}
+        if graphdata.relative:
+            if graphdata.absolute_relative:
+                x_label = "sample runtime (HH:MM:SS)"
+                format = "%H:%M:%S"
+            else:
+                x_label = "sample runtime (seconds)"
+                format = None
+        else:
+            x_label = "sample timestamp"
+            format = "%Y:%M:%d %X %Z"
+        xaxis = {
+            "title": {
+                "text": x_label,
+                "font": {"color": "gray", "variant": "petite-caps", "weight": 1000},
+            },
+        }
+        if format:
+            xaxis["type"] = "date"
+            xaxis["tickformat"] = format
+        layout: dict[str, Any] = {
+            "showlegend": True,
+            "responsive": True,
+            "autosize": True,
+            "xaxis_title": x_label,
+            "yaxis_title": "Metric value",
+            "xaxis": xaxis,
+            "legend": {
+                "xref": "container",
+                "yref": "container",
+                "xanchor": "right",
+                "yanchor": "top",
+                "x": 0.9,
+                "y": 1,
+                "orientation": "h",
+            },
+        }
         axes = {}
         yaxis = None
         cindex = 0
@@ -1883,6 +1926,9 @@ class CrucibleService:
             run_id = g.run
             names = g.names
             metric: str = g.metric
+            run_idx = None
+            if len(run_id_list) > 1:
+                run_idx = f"Run {run_id_list.index(run_id) + 1}"
 
             # The caller can provide a title for each graph; but, if not, we
             # journey down dark overgrown pathways to fabricate a default with
@@ -1970,13 +2016,17 @@ class CrucibleService:
                 if graphdata.relative:
                     if not first:
                         first = p.begin
-                    s = (p.begin - first) / 1000.0
-                    e = (p.end - first) / 1000.0
+                    if graphdata.absolute_relative:
+                        s = self._format_timestamp(p.begin - first)
+                        e = self._format_timestamp(p.end - first)
+                    else:
+                        s = (p.begin - first) / 1000
+                        e = (p.end - first) / 1000
                     x.extend([s, e])
                 else:
-                    x.extend(
-                        [self._format_timestamp(p.begin), self._format_timestamp(p.end)]
-                    )
+                    s = self._format_timestamp(p.begin)
+                    e = self._format_timestamp(p.end)
+                    x.extend([s, e])
                 y.extend([p.value, p.value])
                 y_max = max(y_max, p.value)
 
@@ -1994,11 +2044,14 @@ class CrucibleService:
                 "type": "scatter",
                 "mode": "line",
                 "marker": {"color": color},
-                "labels": {
-                    "x": "sample timestamp",
-                    "y": "samples / second",
-                },
             }
+
+            if run_idx:
+                graphitem["legendgroup"] = run_idx
+                graphitem["legendgrouptitle"] = {
+                    "text": run_idx,
+                    "font": {"variant": "small-caps", "style": "italic"},
+                }
 
             # Y-axis scaling and labeling is divided by benchmark label;
             # so store each we've created to reuse. (E.g., if we graph

--- a/backend/tests/unit/test_crucible.py
+++ b/backend/tests/unit/test_crucible.py
@@ -1886,10 +1886,6 @@ class TestCrucible:
             expected = {
                 "data": [
                     {
-                        "labels": {
-                            "x": "sample timestamp",
-                            "y": "samples / second",
-                        },
                         "marker": {
                             "color": "black",
                         },
@@ -1912,7 +1908,32 @@ class TestCrucible:
                     },
                 ],
                 "layout": {
-                    "width": "1500",
+                    "autosize": True,
+                    "legend": {
+                        "orientation": "h",
+                        "x": 0.9,
+                        "xanchor": "right",
+                        "xref": "container",
+                        "y": 1,
+                        "yanchor": "top",
+                        "yref": "container",
+                    },
+                    "responsive": True,
+                    "showlegend": True,
+                    "xaxis": {
+                        "tickformat": "%Y:%M:%d %X %Z",
+                        "title": {
+                            "font": {
+                                "color": "gray",
+                                "variant": "petite-caps",
+                                "weight": 1000,
+                            },
+                            "text": "sample timestamp",
+                        },
+                        "type": "date",
+                    },
+                    "xaxis_title": "sample timestamp",
+                    "yaxis_title": "Metric value",
                     "yaxis": {
                         "color": "black",
                         "title": "source::type",
@@ -1923,10 +1944,6 @@ class TestCrucible:
             expected = {
                 "data": [
                     {
-                        "labels": {
-                            "x": "sample timestamp",
-                            "y": "samples / second",
-                        },
                         "marker": {
                             "color": "black",
                         },
@@ -1949,7 +1966,32 @@ class TestCrucible:
                     },
                 ],
                 "layout": {
-                    "width": "1500",
+                    "autosize": True,
+                    "legend": {
+                        "orientation": "h",
+                        "x": 0.9,
+                        "xanchor": "right",
+                        "xref": "container",
+                        "y": 1,
+                        "yanchor": "top",
+                        "yref": "container",
+                    },
+                    "responsive": True,
+                    "showlegend": True,
+                    "xaxis": {
+                        "tickformat": "%Y:%M:%d %X %Z",
+                        "title": {
+                            "font": {
+                                "color": "gray",
+                                "variant": "petite-caps",
+                                "weight": 1000,
+                            },
+                            "text": "sample timestamp",
+                        },
+                        "type": "date",
+                    },
+                    "xaxis_title": "sample timestamp",
+                    "yaxis_title": "Metric value",
                     "yaxis": {
                         "color": "black",
                         "title": "source::type",

--- a/frontend/src/actions/ilabActions.js
+++ b/frontend/src/actions/ilabActions.js
@@ -285,15 +285,7 @@ export const fetchGraphData = (uid) => async (dispatch, getState) => {
       graphs,
     });
     if (response.status === 200) {
-      response.data.layout["showlegend"] = true;
-      response.data.layout["responsive"] = "true";
-      response.data.layout["autosize"] = "true";
-      response.data.layout["legend"] = {
-        orientation: "h",
-        xanchor: "left",
-        yanchor: "top",
-        y: -0.1,
-      };
+      response.data.layout["width"] = 1500;
       copyData.push({
         uid,
         data: response.data.data,
@@ -378,17 +370,11 @@ export const fetchMultiGraphData = (uids) => async (dispatch, getState) => {
     const response = await API.post(`/api/v1/ilab/runs/multigraph`, {
       name: "comparison",
       relative: true,
+      absolute_relative: true,
       graphs,
     });
     if (response.status === 200) {
-      response.data.layout["showlegend"] = true;
-      response.data.layout["responsive"] = "true";
-      response.data.layout["autosize"] = "true";
-      response.data.layout["legend"] = {
-        orientation: "h",
-        xanchor: "left",
-        yanchor: "top",
-      };
+      response.data.layout["width"] = 1500;
       const graphData = [];
       graphData.push({
         data: response.data.data,

--- a/frontend/src/actions/ilabActions.js
+++ b/frontend/src/actions/ilabActions.js
@@ -286,7 +286,6 @@ export const fetchGraphData = (uid) => async (dispatch, getState) => {
       graphs,
     });
     if (response.status === 200) {
-      // response.data.layout["width"] = 1500;
       copyData.push({
         uid,
         data: response.data.data,

--- a/frontend/src/components/organisms/Pagination/index.jsx
+++ b/frontend/src/components/organisms/Pagination/index.jsx
@@ -8,9 +8,11 @@ import {
 import PropTypes from "prop-types";
 import { useCallback } from "react";
 import { useDispatch } from "react-redux";
+import { useNavigate } from "react-router-dom";
 
 const RenderPagination = (props) => {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
 
   const perPageOptions = [
     { title: "10", value: 10 },
@@ -21,26 +23,26 @@ const RenderPagination = (props) => {
 
   const onSetPage = useCallback(
     (_evt, newPage, _perPage, startIdx, endIdx) => {
-      dispatch(setPage(newPage, props.type));
+      dispatch(setPage(newPage, props.type, navigate));
     },
-    [dispatch, props.type]
+    [dispatch, props.type, navigate]
   );
   const onPerPageSelect = useCallback(
     (_evt, newPerPage, newPage, startIdx, endIdx) => {
-      dispatch(setPageOptions(newPage, newPerPage, props.type));
+      dispatch(setPageOptions(newPage, newPerPage, props.type, navigate));
       dispatch(checkTableData(newPage, props.type));
     },
-    [dispatch, props.type]
+    [dispatch, props.type, navigate]
   );
 
   const onNextClick = useCallback(
     (_evt, newPage) => {
       if (props.type === "cpt") {
-        dispatch(setPage(newPage, props.type));
+        dispatch(setPage(newPage, props.type, navigate));
       }
       dispatch(checkTableData(newPage, props.type));
     },
-    [dispatch, props.type]
+    [dispatch, props.type, navigate]
   );
   return (
     <Pagination

--- a/frontend/src/components/templates/ILab/ILabMetadata.jsx
+++ b/frontend/src/components/templates/ILab/ILabMetadata.jsx
@@ -1,6 +1,3 @@
-import PropType from "prop-types";
-import { uid } from "@/utils/helper";
-import MetaRow from "./MetaRow";
 import {
   Accordion,
   AccordionContent,
@@ -9,9 +6,13 @@ import {
   Split,
   SplitItem,
 } from "@patternfly/react-core";
-import { Table, Tbody, Th, Thead, Tr, Td } from "@patternfly/react-table";
-import { setMetaRowExpanded } from "@/actions/ilabActions";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import { useDispatch, useSelector } from "react-redux";
+
+import MetaRow from "./MetaRow";
+import PropType from "prop-types";
+import { setMetaRowExpanded } from "@/actions/ilabActions";
+import { uid } from "@/utils/helper";
 
 const ILabMetadata = (props) => {
   const { item } = props;
@@ -42,8 +43,8 @@ const ILabMetadata = (props) => {
             ["name", item.name],
             ["email", item.email],
             ["source", item.source],
-            ["start_date", (new Date(item.begin)).toLocaleString()],
-            ["end_date", (new Date(item.end)).toLocaleString()],
+            ["start_date", new Date(item.begin).toLocaleString()],
+            ["end_date", new Date(item.end).toLocaleString()],
             ["status", item.status],
           ]}
         />
@@ -101,7 +102,7 @@ const ILabMetadata = (props) => {
                       Object.entries(i.params)
                         .filter((p) => !(p[0] in item.params))
                         .map((p) => (
-                          <Tr>
+                          <Tr key={uid()}>
                             <Td>{i.iteration}</Td>
                             <Td>{p[0]}</Td>
                             <Td>{p[1]}</Td>

--- a/frontend/src/components/templates/ILab/ILabSummary.jsx
+++ b/frontend/src/components/templates/ILab/ILabSummary.jsx
@@ -1,7 +1,17 @@
+import {
+  InnerScrollContainer,
+  OuterScrollContainer,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from "@patternfly/react-table";
+
 import PropType from "prop-types";
 import { uid } from "@/utils/helper";
 import { useSelector } from "react-redux";
-import { Table, Tbody, Th, Thead, Tr, Td } from "@patternfly/react-table";
 
 const ILabSummary = (props) => {
   const { ids } = props;
@@ -19,66 +29,74 @@ const ILabSummary = (props) => {
   };
 
   return (
-    <div>
-      {hasSummaryData(ids) ? (
-        <Table
-          variant="compact"
-          hasNoInset
-          className="summary-table"
-          key={uid()}
-          aria-label="Statistical summary table"
-        >
-          <Thead noWrap>
-            <Tr>
-              {ids.length > 1 ? <Th>Run</Th> : <></>}
-              <Th>Metric</Th>
-              <Th>Min</Th>
-              <Th>Average</Th>
-              <Th>Max</Th>
-              <Th>Standard Deviation</Th>
-            </Tr>
-          </Thead>
-          <Tbody>
-            {ids.map((id, ridx) =>
-              getSummaryData(id).data.map((stat, sidx) => (
-                <Tr key={uid()} {...(ridx % 2 === 0 && { isStriped: true })}>
-                  {ids.length > 1 && sidx === 0 ? (
-                    <Td rowSpan={getSummaryData(id).data.length}>{ridx + 1}</Td>
-                  ) : (
-                    <></>
-                  )}
-                  <Td>{stat.title}</Td>
-                  <Td>
-                    {typeof stat.min === "number"
-                      ? stat.min.toPrecision(6)
-                      : stat.min}
-                  </Td>
-                  <Td>
-                    {typeof stat.avg === "number"
-                      ? stat.avg.toPrecision(6)
-                      : stat.avg}
-                  </Td>
-                  <Td>
-                    {typeof stat.max === "number"
-                      ? stat.max.toPrecision(6)
-                      : stat.max}
-                  </Td>
-                  <Td>
-                    {typeof stat.std_deviation === "number"
-                      ? stat.std_deviation.toPrecision(6)
-                      : stat.std_deviation}
-                  </Td>
+    <>
+      <OuterScrollContainer>
+        <InnerScrollContainer>
+          {hasSummaryData(ids) ? (
+            <Table
+              variant="compact"
+              hasNoInset
+              className="summary-table"
+              key={uid()}
+              aria-label="Statistical summary table"
+              isStickyHeader
+              isStriped
+            >
+              <Thead noWrap>
+                <Tr>
+                  {ids.length > 1 ? <Th>Run</Th> : <></>}
+                  <Th>Metric</Th>
+                  <Th>Min</Th>
+                  <Th>Average</Th>
+                  <Th>Max</Th>
+                  <Th>Standard Deviation</Th>
                 </Tr>
-              ))
-            )}
-          </Tbody>
-        </Table>
-      ) : isSummaryLoading && !hasSummaryData(ids) ? (
-        <div className="loader"></div>
-      ) : (
-        <></>
-      )}
-    </div>
+              </Thead>
+              <Tbody>
+                {ids.map((id, ridx) =>
+                  getSummaryData(id).data.map((stat, sidx) => (
+                    <Tr key={uid()}>
+                      {ids.length > 1 && sidx === 0 ? (
+                        <Td rowSpan={getSummaryData(id).data.length}>
+                          {ridx + 1}
+                        </Td>
+                      ) : (
+                        <></>
+                      )}
+                      <Td>{stat.title}</Td>
+                      <Td>
+                        {typeof stat.min === "number"
+                          ? stat.min.toPrecision(6)
+                          : stat.min}
+                      </Td>
+                      <Td>
+                        {typeof stat.avg === "number"
+                          ? stat.avg.toPrecision(6)
+                          : stat.avg}
+                      </Td>
+                      <Td>
+                        {typeof stat.max === "number"
+                          ? stat.max.toPrecision(6)
+                          : stat.max}
+                      </Td>
+                      <Td>
+                        {typeof stat.std_deviation === "number"
+                          ? stat.std_deviation.toPrecision(6)
+                          : stat.std_deviation}
+                      </Td>
+                    </Tr>
+                  ))
+                )}
+              </Tbody>
+            </Table>
+          ) : isSummaryLoading && !hasSummaryData(ids) ? (
+            <div className="loader"></div>
+          ) : (
+            <></>
+          )}
+        </InnerScrollContainer>
+      </OuterScrollContainer>
+    </>
   );
 };
 

--- a/frontend/src/components/templates/ILab/IlabCompareComponent.jsx
+++ b/frontend/src/components/templates/ILab/IlabCompareComponent.jsx
@@ -11,24 +11,24 @@ import {
   StackItem,
   Title,
 } from "@patternfly/react-core";
+import {
+  fetchMetricsInfo,
+  fetchPeriods,
+  handleMultiGraph,
+  handleSummaryData,
+} from "@/actions/ilabActions.js";
 import { useDispatch, useSelector } from "react-redux";
 
+import ILabMetadata from "./ILabMetadata";
+import ILabSummary from "./ILabSummary";
 import { InfoCircleIcon } from "@patternfly/react-icons";
+import MetricsSelect from "./MetricsDropdown";
 import Plot from "react-plotly.js";
 import PropTypes from "prop-types";
 import RenderPagination from "@/components/organisms/Pagination";
 import { cloneDeep } from "lodash";
-import {
-  fetchPeriods,
-  handleMultiGraph,
-  handleSummaryData,
-  fetchMetricsInfo,
-} from "@/actions/ilabActions.js";
 import { uid } from "@/utils/helper";
 import { useState } from "react";
-import ILabSummary from "./ILabSummary";
-import ILabMetadata from "./ILabMetadata";
-import MetricsSelect from "./MetricsDropdown";
 
 const IlabCompareComponent = () => {
   // const { data } = props;
@@ -91,12 +91,15 @@ const IlabCompareComponent = () => {
                         position="auto"
                         className="mini-metadata"
                         bodyContent={
-                          <div position="auto" className="mini-metadata">
+                          <div className="mini-metadata">
                             <ILabMetadata item={item} />
                           </div>
                         }
                       >
-                        <Button icon={<InfoCircleIcon aria-hidden />}></Button>
+                        <Button
+                          variant="plain"
+                          icon={<InfoCircleIcon aria-hidden />}
+                        ></Button>
                       </Popover>
                     }
                   >
@@ -116,35 +119,37 @@ const IlabCompareComponent = () => {
           type={"ilab"}
         />
       </div>
-      <Stack hasGutter>
-        <StackItem span={12} className="metrics-select">
-          <MetricsSelect ids={selectedItems} />
-        </StackItem>
-        <StackItem span={12} className="summary-box">
-          {isSummaryLoading ? (
-            <div className="loader"></div>
-          ) : summaryData.filter((i) => selectedItems.includes(i.uid)).length ==
-            selectedItems.length ? (
-            <ILabSummary ids={selectedItems} />
-          ) : (
-            <div>No data to summarize</div>
-          )}
-        </StackItem>
-        <StackItem span={12} className="chart-box">
-          {isGraphLoading ? (
-            <div className="loader"></div>
-          ) : graphDataCopy?.length > 0 &&
-            graphDataCopy?.[0]?.data?.length > 0 ? (
-            <Plot
-              data={graphDataCopy[0]?.data}
-              layout={graphDataCopy[0]?.layout}
-              key={uid()}
-            />
-          ) : (
-            <div>No data to compare</div>
-          )}
-        </StackItem>
-      </Stack>
+      <div className="chart-container">
+        <Stack hasGutter>
+          <StackItem span={12} className="metrics-select">
+            <MetricsSelect ids={selectedItems} />
+          </StackItem>
+          <StackItem span={12} className="summary-box">
+            {isSummaryLoading ? (
+              <div className="loader"></div>
+            ) : summaryData.filter((i) => selectedItems.includes(i.uid))
+                .length == selectedItems.length ? (
+              <ILabSummary ids={selectedItems} />
+            ) : (
+              <div>No data to summarize</div>
+            )}
+          </StackItem>
+          <StackItem span={12} className="chart-box">
+            {isGraphLoading ? (
+              <div className="loader"></div>
+            ) : graphDataCopy?.length > 0 &&
+              graphDataCopy?.[0]?.data?.length > 0 ? (
+              <Plot
+                data={graphDataCopy[0]?.data}
+                layout={graphDataCopy[0]?.layout}
+                key={uid()}
+              />
+            ) : (
+              <div>No data to compare</div>
+            )}
+          </StackItem>
+        </Stack>
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/templates/ILab/IlabCompareComponent.jsx
+++ b/frontend/src/components/templates/ILab/IlabCompareComponent.jsx
@@ -116,7 +116,7 @@ const IlabCompareComponent = () => {
           type={"ilab"}
         />
       </div>
-      <Stack>
+      <Stack hasGutter>
         <StackItem span={12} className="metrics-select">
           <MetricsSelect ids={selectedItems} />
         </StackItem>

--- a/frontend/src/components/templates/ILab/IlabExpandedRow.jsx
+++ b/frontend/src/components/templates/ILab/IlabExpandedRow.jsx
@@ -69,7 +69,7 @@ const IlabRowContent = (props) => {
         >
           <div>Metrics:</div>
           <MetricsSelect ids={[item.id]} />
-          <Stack>
+          <Stack hasGutter>
             <StackItem key={uid()} id="summary" className="summary-card">
               <ILabSummary ids={[item.id]} />
             </StackItem>

--- a/frontend/src/components/templates/ILab/MetricsDropdown.jsx
+++ b/frontend/src/components/templates/ILab/MetricsDropdown.jsx
@@ -45,8 +45,9 @@ const MetricsSelect = (props) => {
   };
 
   const onOpenChange = async (nextOpen) => {
-    if (!nextOpen) {
+    if (!nextOpen && ids.length > 0) {
       // If we're closing, fetch data
+
       if (ids.length === 1) {
         await Promise.all([
           await dispatch(fetchGraphData(ids[0])),
@@ -58,7 +59,7 @@ const MetricsSelect = (props) => {
           await dispatch(handleSummaryData(ids)),
         ]);
       }
-    };
+    }
     setIsOpen(nextOpen);
   };
 

--- a/frontend/src/components/templates/ILab/index.jsx
+++ b/frontend/src/components/templates/ILab/index.jsx
@@ -17,6 +17,8 @@ import {
   fetchSummaryData,
   setIlabDateFilter,
   toggleComparisonSwitch,
+  updateFromURL,
+  updateURL,
 } from "@/actions/ilabActions";
 import { formatDateTime, uid } from "@/utils/helper";
 import { useDispatch, useSelector } from "react-redux";
@@ -82,13 +84,19 @@ const ILab = () => {
       for (const key in params) {
         obj[key] = params[key].split(",");
       }
-      dispatch(setIlabDateFilter(startDate, endDate, navigate));
+      if (startDate || endDate) {
+        dispatch(setIlabDateFilter(startDate, endDate, navigate));
+      }
+
+      dispatch(updateFromURL(obj));
+    } else {
+      dispatch(updateURL(navigate));
     }
   }, []);
 
   useEffect(() => {
     dispatch(fetchIlabJobs());
-  }, [dispatch]);
+  }, [dispatch, navigate]);
 
   const columnNames = {
     benchmark: "Benchmark",
@@ -113,6 +121,7 @@ const ILab = () => {
 
   const onSwitchChange = () => {
     dispatch(toggleComparisonSwitch());
+    dispatch(updateURL(navigate));
   };
 
   return (
@@ -150,7 +159,7 @@ const ILab = () => {
             <Tbody>
               {results.map((item, rowIndex) => (
                 <>
-                  <Tr key={uid()}>
+                  <Tr key={item.id}>
                     <Td
                       expand={{
                         rowIndex,
@@ -168,7 +177,7 @@ const ILab = () => {
                       <StatusCell value={item.status} />
                     </Td>
                   </Tr>
-                  <Tr key={uid()} isExpanded={isResultExpanded(item.id)}>
+                  <Tr key={`${item.id}-exp`} isExpanded={isResultExpanded(item.id)}>
                     <Td colSpan={8}>
                       <ExpandableRowContent>
                         <IlabRowContent item={item} />

--- a/frontend/src/components/templates/ILab/index.less
+++ b/frontend/src/components/templates/ILab/index.less
@@ -14,7 +14,7 @@
 .comparison-container {
     display: flex;
     width: 100%;
-    height: 80%;
+    height: 90%;
     .metrics-container {
         width: 40%;
         padding: 10px;
@@ -30,23 +30,21 @@
         width: 80%;
         .js-plotly-plot {
             width: 100%;
-            height: 100%;
             overflow-x: auto;
-            overflow-y: visible;
         }
+        .summary-box {
+            width: 100%;
+            max-height: 60%;
+        }
+
     }
     .title {
         margin-bottom: 2vh;
     }
 }
 .mini-metadata {
-    display: inline flex;
+    padding: 5px;
+    display: inline-flex;
     // transform: scale(.75);
 }
-.summary-box {
-    display: inline flex;
-    width: 100%;
-    height: 100%;
-    overflow-x: auto;
-    overflow-y: auto;
-}
+


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The Plotly graphing package doesn't directly support a "delta time" type, and in the comparison view we want to use delta time to compare two runs that will generally have different absolute timestamps. (It turns out that the native PatternFly graphing package, Victory, has the same limitation.)

Initially, this just reported numeric delta seconds, but that's unnatural for a reader. This PR adds support for a absolute_relative option which reports the delta times as small absolute timestamps, like 1970-01-01 00:01:00 for 60 seconds, formatting ticks using "%H:%M:%S" ("00:01:00") for readability.

I also made the X axis title appear, which necessitated some refactoring of the layout to avoid overlaying the legend on the axis label; and in the process I moved the "presentation specific" width parameter into the UI and the others into the API so they don't have to be duplicated in the two action calls.
![image](https://github.com/user-attachments/assets/5764cdcb-7b08-466e-a750-42f6c8607faf)


## Related Tickets & Documents

[PANDA-866](https://issues.redhat.com/browse/PANDA-866) delta time/ UI fixes

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

Tested using `DEVEL=1 backend/tests/functional/setup/test.sh` deployment.