### PR TITLE
Allow toggling individual metrics

### DIFF
--- a/backend/app/services/crucible_svc.py
+++ b/backend/app/services/crucible_svc.py
@@ -2038,6 +2038,7 @@ class CrucibleService:
             "yaxis_title": "Metric value",
             "xaxis": xaxis,
             "legend": {
+                "groupclick": "toggleitem",
                 "xref": "container",
                 "yref": "container",
                 "xanchor": "right",

--- a/backend/tests/unit/test_crucible.py
+++ b/backend/tests/unit/test_crucible.py
@@ -1918,6 +1918,7 @@ class TestCrucible:
                 "layout": {
                     "autosize": True,
                     "legend": {
+                        "groupclick": "toggleitem",
                         "orientation": "h",
                         "x": 0.9,
                         "xanchor": "right",
@@ -1976,6 +1977,7 @@ class TestCrucible:
                 "layout": {
                     "autosize": True,
                     "legend": {
+                        "groupclick": "toggleitem",
                         "orientation": "h",
                         "x": 0.9,
                         "xanchor": "right",


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In the default "legend grouping" configuration, Plotly toggles the entire group when clicking on any metric in a group. That's annoying when you're hoping to focus on the variance in one specific metric across multiple runs.

Luckily, it turns out there's an easy configuration setting to fix this.

(NOTE: the original #166 draft PR grew to include various ILAB UI bug fixes: I'll cherry-pick those in a separate PR.)

## Related Tickets & Documents

[PANDA-870](https://issues.redhat.com/browse/PANDA-870) graph toggle behavior

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

Tested locally
