### PR TITLE
First stage of CDMv9 support

### DIFF
--- a/backend/app/services/crucible_readme.md
+++ b/backend/app/services/crucible_readme.md
@@ -66,6 +66,17 @@ store to find information about runs, tags, params, iterations, samples,
 periods, plus various ways to expose and aggregate metric data both for
 primary benchmarks and non-periodic tools.
 
+The Crucible service supports a range of CDM (Common Data Model) versions. An
+OpenSearch instance may support either CDMv7, CDMv8, or CDMv9. Version 9 adds
+support for a shared OpenSearch instance with a design that intends to support
+mixing several versions; so that, in the future, Crucible would support a single
+server with both CDMv9 and CDMv10 indices, interleaving results from all indices
+within a specified date range.
+
+Note that while the Crucible service currently supports both CDMv7 and CDMv8, CDMv8
+will be automatically selected if CDMv8 indices exist; the service will use only
+one set of indices (either CDMv7 or CDMv8) after initialization.
+
 The `get_runs` API is the primary entry point, returning an object that
 supports filtering, sorting, and pagination of the Crucible run data decorated
 with useful iteration, tag, and parameter data.

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -25,6 +25,6 @@ def fake_elastic(monkeypatch, fake_config):
 
 @pytest.fixture
 async def fake_crucible(fake_elastic):
-    crucible = CrucibleService("TEST", version=7)
+    crucible = CrucibleService("TEST", version="v7dev")
     yield crucible
     await crucible.close()

--- a/backend/tests/unit/fake_elastic.py
+++ b/backend/tests/unit/fake_elastic.py
@@ -51,7 +51,7 @@ class FakeAsyncElasticsearch(AsyncElasticsearch):
         root_index: str,
         hit_list: Optional[list[dict[str, Any]]] = None,
         aggregations: Optional[dict[str, Any]] = None,
-        version: int = 7,
+        version: str = "v7dev",
         repeat: int = 1,
     ):
         """Add a canned response to an Opensearch query
@@ -70,13 +70,12 @@ class FakeAsyncElasticsearch(AsyncElasticsearch):
             version: CDM version
             repeat:
         """
-        ver = f"v{version:d}dev"
-        index = f"cdm{ver}-{root_index}"
+        index = f"cdm{version}-{root_index}"
         hits = []
         if hit_list:
             for d in hit_list:
                 source = d
-                source["cdm"] = {"ver": ver}
+                source["cdm"] = {"ver": version}
                 hits.append(
                     {
                         "_index": index,


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

CDMv9 will be more dynamic, as its designed to coexist with V10. With multiple contributing Crucible controllers, we'll want to support interixed V9 and V10 runs. This requires some data restructuring to capture the version of each CDM object rather than assuming all runs are the same.

I've simplified some code by building DTO (data transfer object) classes to abstract differences from most of the code.

This PR is strictly refactoring, with no change in behavior.

## Related Tickets & Documents

[PANDA-898](https://issues.redhat.com/browse/PANDA-898) CDMv9 name pattern

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

- [x] I added thorough DTO unit tests
- [x] Ran both unit and functional ILAB tests
- [x] Ran manual `curl` queries against local server to verify output