### PR TITLE
Improve unit test reliability

### DIFF
--- a/backend/app/services/crucible_svc.py
+++ b/backend/app/services/crucible_svc.py
@@ -311,7 +311,7 @@ class DTO:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Raw CDM object is missing required keys: "
-                f"{req_keys - act_keys} not in {act_keys}",
+                f"{sorted(req_keys - act_keys)} not in {sorted(act_keys)}",
             )
         self.version = raw["cdm"]["ver"]
         s = raw[self.TYPE]

--- a/backend/tests/unit/test_crucible.py
+++ b/backend/tests/unit/test_crucible.py
@@ -99,7 +99,7 @@ class TestDTOs:
             RunDTO({"foo": {}, "cdm": {"ver": "v7dev"}})
         assert 500 == exc.value.status_code
         assert (
-            "Raw CDM object is missing required keys: {'run'} not in {'cdm', 'foo'}"
+            "Raw CDM object is missing required keys: ['run'] not in ['cdm', 'foo']"
             == exc.value.detail
         )
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

An error message relied on Python's `str` of two sets; the order of the set members sometimes varies, causing spurious failures. Fixed by converting to a sorted list.

## Related Tickets & Documents

[PANDA-904](https://issues.redhat.com/browse/PANDA-904) fix flaky unit test

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

Tested locally
