### PR TITLE
CDMv9 support

### DIFF
--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -28,3 +28,10 @@ async def fake_crucible(fake_elastic):
     crucible = CrucibleService("TEST", version="v7dev")
     yield crucible
     await crucible.close()
+
+
+@pytest.fixture
+async def fake_crucible_v9(fake_elastic):
+    crucible = CrucibleService("TEST", version="v9dev")
+    yield crucible
+    await crucible.close()


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR enables the CPT dashboard to read and display runs from a CDMv9 Crucible database. I've tested against a `cdm-*` namespace on the INTLAB OpenSearch instance.

## Related Tickets & Documents

[PANDA-897](https://issues.redhat.com/browse/PANDA-897) generate index patterns

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

Tested manually against a live CDMv9 database in INTLAB.

I've enhanced the unit tests to cover new code paths. All unit and functional tests pass.

Note that the functional tests don't check CDMv9 data. While Crucible does not intend to support a shared server with mixed CDMv7/CDMv8/CDMv9 data, one possible way forward is to seed our canned OpenSearch with mixed indices. I haven't attempted to do that here.
