### PR TITLE
Add flake8 lint checking

### DIFF
--- a/.github/workflows/backend-check.yaml
+++ b/.github/workflows/backend-check.yaml
@@ -32,8 +32,6 @@ jobs:
           cd backend
           tox -e format,isort
       - name: Check for lint
-        # Report errors but don't fail until we achieve stability!
-        continue-on-error: true
         run: |
           cd backend
           tox -e lint

--- a/backend/.flake8
+++ b/backend/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+ignore = E203,E226,W503,E704
+
+# Black tries to limit lines to 88 characters: keep flake8 from complaining
+# as long as we're below 100.
+max-line-length = 100

--- a/backend/app/api/v1/commons/constants.py
+++ b/backend/app/api/v1/commons/constants.py
@@ -168,11 +168,12 @@ keys_to_keep = ["product", "testName", "jobStatus", "ciSystem", "releaseStream"]
 
 SPLUNK_SEMAPHORE_COUNT = 5  # Arbitrary concurrency limit in an asyncio semaphore
 
-# These products don't need to be included in the filter dict when applying filters on the Home tab,
-# as the filtering function will automatically handle them using the corresponding product-to-mapper lookup.
+# These products don't need to be included in the filter dict when applying
+# filters on the Home tab, as the filtering function will automatically handle
+# them using the corresponding product-to-mapper lookup.
 STANDOUT_PRODUCTS = ["ocp", "telco", "quay"]
 # These products aren't listed by their exact names like "hce" and "ocm",
-# but instead represent grouped categories such as "Developer", "Insights", etc.
+# but instead represent grouped categories such as "Developer" or "Insights".
 GENERAL_PRODUCTS = ["hce", "ocm"]
 TELCO_STATUS_MAP = {"success": "passed", "failed": "failed", "failure": "failure"}
 

--- a/backend/app/api/v1/commons/example_responses.py
+++ b/backend/app/api/v1/commons/example_responses.py
@@ -170,8 +170,11 @@ ols_response_example = {
             "networkType": "OVNKubernetes",
             "buildTag": "1886955825944072192",
             "jobStatus": "success",
-            "buildUrl": "https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/60981/rehearse-60981-periodic-ci-openshift-ols-load-generator-main-ols-load-test-100workers/1886955825944072192",
-            "upstreamJob": "rehearse-60981-periodic-ci-openshift-ols-load-generator-main-ols-load-test-100workers",
+            "buildUrl": "https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/"
+            "pull/openshift_release/60981/rehearse-60981-periodic-ci-openshift-ols-"
+            "load-generator-main-ols-load-test-100workers/1886955825944072192",
+            "upstreamJob": "rehearse-60981-periodic-ci-openshift-ols-load-generator-main-"
+            "ols-load-test-100workers",
             "upstreamJobBuild": "778dd992-8353-4cec-9807-7343290267f8",
             "executionDate": "2025-02-05T03:19:50Z",
             "jobDuration": "3396",

--- a/backend/app/api/v1/commons/hce.py
+++ b/backend/app/api/v1/commons/hce.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date
 
 import pandas as pd
 

--- a/backend/app/api/v1/commons/telco.py
+++ b/backend/app/api/v1/commons/telco.py
@@ -6,7 +6,6 @@ from app import config
 import app.api.v1.commons.constants as constants
 import app.api.v1.commons.hasher as hasher
 import app.api.v1.commons.utils as utils
-import app.api.v1.endpoints.telco.telcoGraphs as telcoGraphs
 from app.services.splunk import SplunkService
 
 
@@ -95,12 +94,6 @@ async def getData(
 async def getFilterData(
     start_datetime: date, end_datetime: date, filter: str, configpath: str
 ):
-
-    cfg = config.get_config()
-    try:
-        jenkins_url = cfg.get("telco.config.job_url")
-    except Exception as e:
-        print(f"Error reading telco configuration: {e}")
 
     query = {
         "earliest_time": "{}T00:00:00".format(start_datetime.strftime("%Y-%m-%d")),

--- a/backend/app/api/v1/commons/utils.py
+++ b/backend/app/api/v1/commons/utils.py
@@ -246,12 +246,15 @@ def update_filter_product(filter):
     filter_dict = get_dict_from_qs(filter) if filter else {}
     filter_product = filter_dict.pop("product", None)
 
-    # The product filter dropdown includes options like "ocp", "telco", "quay", "Developer", "Insights", etc.
+    # The product filter dropdown includes options like "ocp", "telco", "quay",
+    # "Developer", "Insights", etc
+    #
     # Among these, "ocp", "quay", and "telco" are considered STANDOUT_PRODUCTS.
     # These standout products are handled through a product-to-mapper lookup,
-    # so they do NOT need to be included in the filter_dict explicitly.
-    # The remaining products (like "Developer", "Insights", etc.) must be filtered using "hce" and "ocm" mappers,
-    # so they are retained in the filter_dict for backend filtering.
+    # so they do NOT need to be included in the filter_dict explicitly. The
+    # remaining products (like "Developer", "Insights", etc.) must be filtered
+    # using "hce" and "ocm" mappers, so they are retained in the filter_dict
+    # for backend filtering.
 
     if filter_product:
         matched = [p for p in filter_product if p in constants.STANDOUT_PRODUCTS]

--- a/backend/app/api/v1/endpoints/cpt/cptJobs.py
+++ b/backend/app/api/v1/endpoints/cpt/cptJobs.py
@@ -1,7 +1,6 @@
 import asyncio
 from datetime import date, datetime, timedelta
 import json
-from multiprocessing import cpu_count
 import traceback
 from urllib.parse import urlencode
 

--- a/backend/app/api/v1/endpoints/cpt/maps/hce.py
+++ b/backend/app/api/v1/endpoints/cpt/maps/hce.py
@@ -1,5 +1,4 @@
 from datetime import date
-import traceback
 from urllib.parse import urlencode
 
 import pandas as pd
@@ -35,7 +34,7 @@ async def hceMapper(
     updated_filter = await get_updated_filter(filter)
 
     response = await getData(
-        start_datetime, end_datetime, size, offset, updated_filter, f"hce.elasticsearch"
+        start_datetime, end_datetime, size, offset, updated_filter, "hce.elasticsearch"
     )
 
     if isinstance(response, pd.DataFrame) or not response:
@@ -79,7 +78,7 @@ async def hceFilter(start_datetime: date, end_datetime: date, filter: str):
         updated_filter = await get_updated_filter(filter)
 
         response = await getFilterData(
-            start_datetime, end_datetime, updated_filter, f"hce.elasticsearch"
+            start_datetime, end_datetime, updated_filter, "hce.elasticsearch"
         )
 
         if isinstance(response, pd.DataFrame) or not response:

--- a/backend/app/api/v1/endpoints/cpt/maps/ocm.py
+++ b/backend/app/api/v1/endpoints/cpt/maps/ocm.py
@@ -24,7 +24,7 @@ async def ocmMapper(
     updated_filter = await get_updated_filter(filter)
 
     response = await getData(
-        start_datetime, end_datetime, size, offset, filter, f"ocm.elasticsearch"
+        start_datetime, end_datetime, size, offset, updated_filter, "ocm.elasticsearch"
     )
     if isinstance(response, pd.DataFrame) or not response:
         df = response["data"]
@@ -53,7 +53,7 @@ async def ocmFilter(start_datetime: date, end_datetime: date, filter: str):
     updated_filter = await get_updated_filter(filter)
 
     response = await getFilterData(
-        start_datetime, end_datetime, updated_filter, f"ocm.elasticsearch"
+        start_datetime, end_datetime, updated_filter, "ocm.elasticsearch"
     )
     if isinstance(response, pd.DataFrame) or not response:
         return {"total": 0, "filterData": [], "summary": {}}

--- a/backend/app/api/v1/endpoints/cpt/maps/ocp.py
+++ b/backend/app/api/v1/endpoints/cpt/maps/ocp.py
@@ -29,7 +29,7 @@ async def ocpMapper(
         offset,
         sort,
         updated_filter,
-        f"ocp.elasticsearch",
+        "ocp.elasticsearch",
     )
 
     if isinstance(response, pd.DataFrame) or not response:
@@ -51,7 +51,7 @@ async def ocpFilter(start_datetime: date, end_datetime: date, filter: str):
     updated_filter = await get_updated_filter(filter)
 
     response = await getFilterData(
-        start_datetime, end_datetime, updated_filter, f"ocp.elasticsearch"
+        start_datetime, end_datetime, updated_filter, "ocp.elasticsearch"
     )
 
     if isinstance(response, pd.DataFrame) or not response:

--- a/backend/app/api/v1/endpoints/cpt/maps/quay.py
+++ b/backend/app/api/v1/endpoints/cpt/maps/quay.py
@@ -25,7 +25,7 @@ async def quayMapper(
         offset,
         sort,
         updated_filter,
-        f"quay.elasticsearch",
+        "quay.elasticsearch",
     )
 
     if isinstance(response, pd.DataFrame) or not response:
@@ -45,7 +45,7 @@ async def quayFilter(start_datetime: date, end_datetime: date, filter: str):
     updated_filter = await get_updated_filter(filter)
 
     response = await getFilterData(
-        start_datetime, end_datetime, updated_filter, f"quay.elasticsearch"
+        start_datetime, end_datetime, updated_filter, "quay.elasticsearch"
     )
 
     if isinstance(response, pd.DataFrame) or not response:

--- a/backend/app/api/v1/endpoints/cpt/maps/telco.py
+++ b/backend/app/api/v1/endpoints/cpt/maps/telco.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from app.api.v1.commons.constants import keys_to_keep
 from app.api.v1.commons.telco import getData, getFilterData
-from app.api.v1.commons.utils import get_dict_from_qs, getReleaseStream
+from app.api.v1.commons.utils import get_dict_from_qs
 
 
 #####################################################################
@@ -23,7 +23,7 @@ async def telcoMapper(
         offset,
         sort,
         updated_filter,
-        f"telco.splunk",
+        "telco.splunk",
     )
 
     if isinstance(response, pd.DataFrame) or not response:

--- a/backend/app/api/v1/endpoints/horreum/horreum.py
+++ b/backend/app/api/v1/endpoints/horreum/horreum.py
@@ -1,8 +1,6 @@
-from http import HTTPStatus
-from typing import Annotated, Any
+from typing import Annotated
 
 from fastapi import APIRouter, Path, Request, Response
-from fastapi.responses import JSONResponse
 
 from app.services.horreum_svc import HorreumService
 

--- a/backend/app/api/v1/endpoints/ilab/ilab.py
+++ b/backend/app/api/v1/endpoints/ilab/ilab.py
@@ -93,7 +93,7 @@ async def run_filters(crucible: Annotated[CrucibleService, Depends(crucible_svc)
                         "email": "rhel-ai-user@example.com",
                         "id": "bd72561c-cc20-400b-b6f6-d9534a60033a",
                         "name": '"RHEL-AI User"',
-                        "source": "n42-h01-b01-mx750c.example.com//var/lib/crucible/run/ilab--2024-09-11_19:43:53_UTC--bd72561c-cc20-400b-b6f6-d9534a60033a",
+                        "source": "a.example.com//var/lib/crucible/run/ilab--<date>--<uuid>",
                         "status": "pass",
                         "begin_date": "1970-01-01 00:00:00+00:00",
                         "end_date": "1970-01-01 00:00:00+00:00",

--- a/backend/app/api/v1/endpoints/ocp/ocpJobs.py
+++ b/backend/app/api/v1/endpoints/ocp/ocpJobs.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime, timedelta
 import json
 
-from fastapi import APIRouter, HTTPException, Response
+from fastapi import APIRouter, Response
 from fastapi.param_functions import Query
 
 from app.api.v1.commons.utils import normalize_pagination
@@ -131,6 +131,5 @@ async def filters(
         json_str = json.dumps(results, indent=4)
         return Response(content=json_str, media_type="application/json")
     else:
-        response = {"filterData": [], "summary": {}}
         json_str = json.dumps(results, indent=4)
         return Response(content=json_str, media_type="application/json")

--- a/backend/app/api/v1/endpoints/quay/quayGraphs.py
+++ b/backend/app/api/v1/endpoints/quay/quayGraphs.py
@@ -1,7 +1,4 @@
-from datetime import date, datetime, timedelta
-import json
-
-from fastapi import APIRouter, Response
+from fastapi import APIRouter
 
 from app.api.v1.commons.utils import getMetadata
 from app.services.search import ElasticService
@@ -212,7 +209,6 @@ async def getQuayMetrics(uuids: list, index: str):
 
 
 async def getMatchRuns(meta: dict):
-    version = meta["ocpVersion"][:4]
     query = {
         "query": {
             "bool": {

--- a/backend/app/api/v1/endpoints/quay/quayJobs.py
+++ b/backend/app/api/v1/endpoints/quay/quayJobs.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime, timedelta
 import json
 
-from fastapi import APIRouter, HTTPException, Response
+from fastapi import APIRouter, Response
 from fastapi.param_functions import Query
 
 from app.api.v1.commons.utils import normalize_pagination
@@ -133,6 +133,5 @@ async def filters(
         json_str = json.dumps(results, indent=4)
         return Response(content=json_str, media_type="application/json")
     else:
-        response = {"filterData": [], "summary": {}}
         json_str = json.dumps(results, indent=4)
         return Response(content=json_str, media_type="application/json")

--- a/backend/app/api/v1/endpoints/telco/telcoJobs.py
+++ b/backend/app/api/v1/endpoints/telco/telcoJobs.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime, timedelta
 import json
 
-from fastapi import APIRouter, HTTPException, Response
+from fastapi import APIRouter, Response
 from fastapi.param_functions import Query
 
 from app.api.v1.commons.example_responses import response_422, telco_200_response
@@ -75,7 +75,6 @@ async def jobs(
         json_str = json.dumps(response, indent=4)
         return Response(content=json_str, media_type="application/json")
 
-    jsonstring = json.dumps(response)
     return response
 
 
@@ -130,5 +129,4 @@ async def filters(
         json_str = json.dumps(response, indent=4)
         return Response(content=json_str, media_type="application/json")
 
-    jsonstring = json.dumps(response)
     return response

--- a/backend/app/services/crucible_svc.py
+++ b/backend/app/services/crucible_svc.py
@@ -1606,7 +1606,7 @@ class CrucibleService:
                     "end": "1722880503544",
                     "id": "4e1d2c3c-b01c-4007-a92d-23a561af2c11",
                     "name": "\"A User\"",
-                    "source": "node.example.com//var/lib/crucible/run/ilab--2024-08-05_17:17:13_UTC--4e1d2c3c-b01c-4007-a92d-23a561af2c11",
+                    "source": "<host>/<path>/<name>--<date>--<uuid>",
                     "tags": {
                         "topology": "none"
                     },

--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -1,6 +1,5 @@
 import bisect
 from datetime import datetime, timedelta
-import re
 import traceback
 
 from elasticsearch import AsyncElasticsearch
@@ -76,7 +75,10 @@ class ElasticService:
         else:
             """Handles queries that require data from ES docs"""
             if timestamp_field:
-                """Handles queries that have a timestamp field. Queries from both new and archive instances"""
+                """Handles queries that have a timestamp field.
+
+                We handle queries from both new and archive instances
+                """
                 if self.prev_es:
                     self.prev_index = self.prev_index_prefix + (
                         self.prev_index if indice is None else indice

--- a/backend/app/services/splunk.py
+++ b/backend/app/services/splunk.py
@@ -154,7 +154,8 @@ class SplunkService:
                     "values(formal) AS isFormal, "
                     'count(eval(status="passed")) AS pass_count,'
                     'count(eval(like(status,"fail%"))) AS fail_count'
-                    "| fields cpu, nodeName, benchmark, ocpVersion, releaseStream, isFormal, total_records, pass_count, fail_count, jobStatus"
+                    "| fields cpu, nodeName, benchmark, ocpVersion, releaseStream, "
+                    "isFormal, total_records, pass_count, fail_count, jobStatus"
                 )
 
                 # Run Splunk search asynchronously using `oneshot`

--- a/backend/scripts/version.py
+++ b/backend/scripts/version.py
@@ -45,7 +45,7 @@ def main():
         "branch": branch,
         "display_version": display,
         "date": datetime.now(tz=timezone.utc).isoformat(),
-        "changes": [{f: v for f, v in zip(fields, l.split("###"))} for l in log],
+        "changes": [{f: v for f, v in zip(fields, lg.split("###"))} for lg in log],
     }
     with (backend / "version.json").open("w") as verfile:
         json.dump(vj, fp=verfile)

--- a/backend/tests/unit/test_crucible.py
+++ b/backend/tests/unit/test_crucible.py
@@ -737,7 +737,8 @@ class TestFilterBuilders:
         (
             (
                 "foo:asc",
-                "Sort key 'foo' must be one of begin,benchmark,desc,email,end,harness,host,id,name,source",
+                "Sort key 'foo' must be one of begin,benchmark,desc,email,"
+                "end,harness,host,id,name,source",
             ),
             ("email:up", "Sort direction 'up' must be one of asc,desc"),
         ),
@@ -995,7 +996,8 @@ class TestCrucible:
             )
         assert 422 == exc.value.status_code
         assert {
-            "message": f"More than one metric ({message[0]}) means you should add breakout filters or aggregate.",
+            "message": f"More than one metric ({message[0]}) means you "
+            "should add breakout filters or aggregate.",
             "periods": message[1],
             "names": message[2],
         } == exc.value.detail

--- a/backend/tests/utilities/clone_ilab.py
+++ b/backend/tests/utilities/clone_ilab.py
@@ -364,7 +364,8 @@ def clone(source: Elasticsearch, target: Elasticsearch, ids: list[str]):
             )
             if args.verbose > 1:
                 print(
-                    f"Cloning {name} bucket {metric}: {len(ids)} IDs: {len(a['hits']['hits'])} found"
+                    f"Cloning {name} bucket {metric}: {len(ids)} "
+                    f"IDs: {len(a['hits']['hits'])} found"
                 )
             batches = []
             batch = 0

--- a/backend/tests/utilities/diagnose.py
+++ b/backend/tests/utilities/diagnose.py
@@ -283,7 +283,7 @@ def diagnose(cdm: Elasticsearch, args: argparse.Namespace):
                 info.good = False
                 info.errors[f"metric {metrics[id]} sample missing value"] += 1
 
-    watcher.update(f"generating report")
+    watcher.update("generating report")
     baddies = 0
     marks = defaultdict(int)
     metrics = defaultdict(int)
@@ -306,10 +306,12 @@ def diagnose(cdm: Elasticsearch, args: argparse.Namespace):
             if first:
                 first = False
                 print(
-                    f"{'Run ID':<36s} {'Benchmark':<10s} {'Start time':<16s} It Sa Pd Errors Primary"
+                    f"{'Run ID':<36s} {'Benchmark':<10s} {'Start time':<16s} "
+                    "It Sa Pd Errors Primary"
                 )
                 print(
-                    f"{'':-<36s} {'':-<10s} {'':-<16s} {'':-<2s} {'':-<2s} {'':-<2s} {'':-<6s} {'':-<20s}"
+                    f"{'':-<36s} {'':-<10s} {'':-<16s} {'':-<2s} {'':-<2s} "
+                    f"{'':-<2s} {'':-<6s} {'':-<20s}"
                 )
             print(
                 f"{run.id:36s} {run.benchmark:10s} {t:%Y-%m-%d %H:%M} "

--- a/backend/tests/utilities/fix_snapshot.py
+++ b/backend/tests/utilities/fix_snapshot.py
@@ -17,7 +17,6 @@ E.g.:
 
 import argparse
 from collections import defaultdict
-import json
 import sys
 import time
 from typing import Any
@@ -749,9 +748,8 @@ def snapshot(server: Elasticsearch):
                 "Unexpected snapshot: expect functional/base: "
                 f"{snapshot['repository']}/{snapshot['snapshot']}"
             )
-        print(
-            f"Indices: {', '.join([str(i) for i in snapshot['indices'].keys() if i.startswith('cdm')])}"
-        )
+        idxlist = [str(i) for i in snapshot["indices"].keys() if i.startswith("cdm")]
+        print(f"Indices: {', '.join(idxlist)}")
         r = server.snapshot.delete(repository="functional", snapshot="base")
         if r.get("acknowledged") is not True:
             raise Exception(f"Snapshot 'base' deletion failed with {r}")


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The CI will now fail if `flake8` lint checking fails.

A number of minor changes have been made to remove unused imports and break excessively long lines. (Flake8's tolerance is less generous than black's.)

Several unused variable have been removed, including a `version` from the Quay graphs `getMatchRuns` ... the file history shows this was initially used in the query string, but it was removed and (probably inadvertently) restored (without the associated query phrase) by REVAMP. The other main unused variable is "data" in the `ingress-performance` case of the OCP graph API. This code has always been unimplemented; instead of attempting to resolve that here, I've created issue #252.

In one place, flake8 complained about the use of Pandas filter terms ["<field> == True"] because Python (and flake8) want "is True". Experiment shows that Pandas doesn't properly defer execution of the "is True" form, causing an internal error ... I left the "== True" and marked these lines "# noqa" to disable flake8 complaints. (I didn't bother going further in experimentation or analysis.)

## Related Tickets & Documents

[PANDA-758](https://issues.redhat.com/browse/PANDA-758) flake8

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

Quickly verified local deployment of server after resolving flake8 errors.