### PR TITLE
Align CI line limits

### DIFF
--- a/backend/.flake8
+++ b/backend/.flake8
@@ -1,6 +1,2 @@
 [flake8]
-ignore = E203,E226,W503,E704
-
-# Black tries to limit lines to 88 characters: keep flake8 from complaining
-# as long as we're below 100.
-max-line-length = 100
+ignore = E203,E226,E501,W503,E701,E704

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -43,6 +43,9 @@ watchgod = "^0.7"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 
+[tool.black]
+line-length = 88
+
 [tool.isort]
 profile = "black"                 # black-compatible (e.g., trailing comma)
 known_first_party = ["app"]       # separate our headers into a section


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This adds E501 (line length) to the set of *ignored* `flake8` errors.

We already rely on `black` to verify Python source code, and `black` will break lines to 88 characters if possible; there's no additional value in having `flake8` fail when `black` is unable to do this. (Though we should always strive to keep strings and comments within 80 columns if possible.)

This also adds an explicit `[tool.black]` section to `pyproject.toml` although we only specify the canonical default value of 88 for `line-length` at this time.

## Related Tickets & Documents

[PANDA-993](https://issues.redhat.com/browse/PANDA-993) reconcile black and flake8 line limits

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

Ran `black`, `isort`, `flake8` locally