### PR TITLE
Minor development environment changes

### DIFF
--- a/backend/app/services/crucible_svc.py
+++ b/backend/app/services/crucible_svc.py
@@ -726,7 +726,9 @@ class CrucibleService:
         self.auth = (self.user, self.password) if self.user or self.password else None
         self.url = self.cfg.get(configpath + ".url")
         self.versions = set()
-        self.elastic = AsyncElasticsearch(self.url, http_auth=self.auth)
+        self.elastic = AsyncElasticsearch(
+            self.url, http_auth=self.auth, verify_certs=False
+        )
         self.logger.info("Initializing CDM service to %s", self.url)
 
     async def detect_versions(self):

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -173,7 +173,6 @@ description = "Timeout context manager for asyncio programs"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "python_version < \"3.11\""
 files = [
     {file = "async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c"},
     {file = "async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"},
@@ -702,7 +701,6 @@ description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "python_version < \"3.11\""
 files = [
     {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
     {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
@@ -1999,7 +1997,6 @@ description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "python_full_version <= \"3.11.0a6\""
 files = [
     {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
     {file = "tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6"},
@@ -2489,5 +2486,5 @@ propcache = ">=0.2.1"
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.9"
-content-hash = "50e3d1df7a192fd3ffb228cb3b1711b4b5de7984673da007c5fc2dfaab41ce59"
+python-versions = ">=3.9,<3.10"
+content-hash = "6d527f6f27762f373197721f3d1af2936e1d8150b28b0f5e6d5f1b3c505988c6"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openshift_perfscale_api"
-requires-python = "^3.9"
+requires-python = ">=3.9,<3.10"
 dynamic = ["dependencies"]
 version = "0.1.1"
 description = "Python transformer of OpenShift performance and scale test results"
@@ -23,7 +23,7 @@ numpy = "1.26.4"
 orjson = "^3.5.3"
 pandas = "1.2.4"
 pydantic = "2.10.5"
-python = "^3.9"
+python = ">=3.9,<3.10"
 python-keycloak = "^3.12.0"
 pytest = "^8.3.5"
 pytest-asyncio = "^0.24"

--- a/local-compose.sh
+++ b/local-compose.sh
@@ -1,10 +1,28 @@
 #!/bin/sh
 #
-# Simple script to build the frontend and backend, and deploy to test out the changes
-# Need:
+# Simple script to build the frontend and backend, and deploy to test changes
+#
+# Requirements/Assumptions:
 # - Users will need to update the backend/ocpperf.toml file to meet their needs.
+# - You must have both podman and docker installed: we use "podman compose".
+#   However the podman compose engine isn't complete and won't work: but the
+#   "podman compose" command uses the docker compose engine if installed, which
+#   does work.
 #
+# Usage:
+#   ./local-compose.sh
 #
+#   This will build the frontend and backend containers, and deploy them locally
+#   to assist in development. Note that these containers don't react to source
+#   changes, so `./run-local.sh` may be a better option for active development.
+#
+#   Also, as our real deployment is based on Kubernetes applications, services,
+#   and routes, docker compose is not an accurate simulation of the real
+#   deployment. An alternative is to set up a local minikube or OpenShift Local
+#   and deploy there for testing -- instructions and scripting support TBD.
+#
+# Assisted-by: Cursor AI
+
 TOP=$(git rev-parse --show-toplevel)
 BACKEND=${TOP}/backend
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "cpt-dashboard",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}

--- a/run-local.sh
+++ b/run-local.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# Run the backend and frontend locally in a mode where saving changes will
+# immediately update the running instances. This is useful for active
+# development.
+#
+# Usage:
+#   ./run-local.sh
+#
+# Need:
+# - Users will need to update the backend/ocpperf.toml file to meet their needs.
+#
+# TBD:
+# - Add a way to automatically configure the functional test OpenSearch database
+#   snapshots with the appropriate ocpperf.toml file, which may be useful for
+#   testing.
+#
+# Assisted-by: Cursor AI
+TOP=$(git rev-parse --show-toplevel)
+BACKEND=${TOP}/backend
+FRONTEND=${TOP}/frontend
+CPT_CONFIG=${CPT_CONFIG:-"${BACKEND}/ocpperf.toml"}
+if [ ! -f "${CPT_CONFIG}" ]; then
+    echo "Error: ${CPT_CONFIG} not found" >&2
+    echo "Please update the backend/ocpperf.toml file to meet your needs." >&2
+    exit 1
+fi
+
+# start the backend
+(
+    cd "${BACKEND}"
+    poetry install
+    poetry run scripts/start-reload.sh
+) &
+backend_pid=$!
+
+# start the frontend
+(
+    cd "${FRONTEND}"
+    npm install
+    npm run dev
+) &
+frontend_pid=$!
+
+# Killing the subshells won't kill all child processes, so grab their process
+# group IDs and use those instead. They're likely in the same PGID; but check
+# both to be sure.
+b_pgid=$(ps -o pgid= -p ${backend_pid})
+f_pgid=$(ps -o pgid= -p ${frontend_pid})
+
+# Remove the leading space from "ps -o" output
+backend_pgid=${b_pgid# }
+frontend_pgid=${f_pgid# }
+
+to_kill="-${backend_pgid}"
+if [[ ${frontend_pgid} -ne ${backend_pgid} ]]; then
+    to_kill="${to_kill} -${frontend_pgid}"
+fi
+
+# Let frontend and backend start up and write their output before we finish,
+# or our helpful note will be lost.
+sleep 4
+
+echo "CPT Backend is running in the background at http://localhost:8000"
+echo "CPT Frontend is running in the background at http://localhost:3000"
+echo ""
+echo "To terminate, run:"
+echo "  kill -- ${to_kill}"
+echo ""
+echo "HINT: capture this in an environment variable for later:"
+echo "  export KILL_CMD=\"kill -- ${to_kill}\""
+echo "and then you can terminate with \$KILL_CMD"


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

1. Add run-local.sh to help developers run local frontend and backend components for development
2. Fix the pyproject.toml file to correctly lock the Python version to 3.9.*
3. A minor change to Crucible connection: the frontend container lacks the Red Hat CA and can't verify the TLS certificate for an https connection to the INTLAB OpenSearch instance. We should fix the container build; but for now just disable verification.

## Related Tickets & Documents

[PANDA-905](https://issues.redhat.com/browse/PANDA-905) dev environment

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Local testing, including frontend & backend functional tests
