### PR TITLE
Fix OpenSearch bucket aggregations

### DIFF
--- a/backend/app/api/v1/commons/constants.py
+++ b/backend/app/api/v1/commons/constants.py
@@ -29,6 +29,7 @@ FIELDS = (
     "formal",
     "ciSystem",
 )
+AGG_BUCKET_SIZE = 1000
 MAX_PAGE = 10000
 OCP_SHORT_VER_LEN = 6
 

--- a/backend/app/api/v1/commons/utils.py
+++ b/backend/app/api/v1/commons/utils.py
@@ -124,7 +124,7 @@ def normalize_pagination(offset: Optional[int], size: Optional[int]) -> tuple[in
 def buildAggregateQuery(constant_dict):
     aggregate = {}
     for x, y in constant_dict.items():
-        obj = {x: {"terms": {"field": y}}}
+        obj = {x: {"terms": {"field": y, "size": constants.AGG_BUCKET_SIZE}}}
         aggregate.update(obj)
     return aggregate
 

--- a/backend/app/api/v1/endpoints/ocp/graph.py
+++ b/backend/app/api/v1/endpoints/ocp/graph.py
@@ -3,6 +3,7 @@ import pprint
 from fastapi import APIRouter
 import pandas as pd
 
+from app.api.v1.commons.constants import AGG_BUCKET_SIZE
 from app.api.v1.commons.utils import getMetadata
 from app.services.search import ElasticService
 
@@ -381,11 +382,11 @@ async def getBurnerCPUResults(uuids: list, namespace: str, index: str):
         "size": 0,
         "aggs": {
             "time": {
-                "terms": {"field": "uuid.keyword"},
+                "terms": {"field": "uuid.keyword", "size": AGG_BUCKET_SIZE},
                 "aggs": {"time": {"avg": {"field": "timestamp"}}},
             },
             "uuid": {
-                "terms": {"field": "uuid.keyword"},
+                "terms": {"field": "uuid.keyword", "size": AGG_BUCKET_SIZE},
                 "aggs": {"cpu": {"avg": {"field": "value"}}},
             },
         },

--- a/backend/app/api/v1/endpoints/quay/quayGraphs.py
+++ b/backend/app/api/v1/endpoints/quay/quayGraphs.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 
+from app.api.v1.commons.constants import AGG_BUCKET_SIZE
 from app.api.v1.commons.utils import getMetadata
 from app.services.search import ElasticService
 
@@ -157,7 +158,7 @@ async def getImageMetrics(uuids: list, index: str):
         "size": 0,
         "aggs": {
             "uuid": {
-                "terms": {"field": "uuid.keyword"},
+                "terms": {"field": "uuid.keyword", "size": AGG_BUCKET_SIZE},
                 "aggs": {
                     "latency": {"avg": {"field": "elapsed_time"}},
                     "success_count": {"sum": {"field": "success_count"}},

--- a/backend/tests/unit/test_utils.py
+++ b/backend/tests/unit/test_utils.py
@@ -423,9 +423,9 @@ class TestQueryConstruction:
 
         expected_result = {
             "aggregate_structure": {
-                "platform": {"terms": {"field": "platform.keyword"}},
-                "benchmark": {"terms": {"field": "benchmark.keyword"}},
-                "jobStatus": {"terms": {"field": "jobStatus.keyword"}},
+                "platform": {"terms": {"field": "platform.keyword", "size": 1000}},
+                "benchmark": {"terms": {"field": "benchmark.keyword", "size": 1000}},
+                "jobStatus": {"terms": {"field": "jobStatus.keyword", "size": 1000}},
             },
             "correct_structure": True,
         }


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In order to build filter lists, we collect the values assigned to each key using an OpenSearch bucket aggregation. Unfortunately, by default, a bucket aggregation returns only the first 10 buckets; in at least one specific case where someone noticed (the releaseStream keyword) we've exceeded 10 values and expected terms aren't being reported.

This uses the `field`'s `size` keyword to return up to 1000 buckets instead. This is likely overkill for many cases, but should be "safe" for most cases.

I considered adding code into `search.py` to analyzed returned bucket aggregations for a non-zero `sum_other_doc_count` (which means we could have returned additional terms), and report any case where this happens for log stream analysis. This doesn't solve any additional problems, however, adds more code, and is a little tricky given the logic to merge aggregations against two OpenSearch instances. If some reviewer wants to insist, or if I start feeling too guilty before I get an approval, I'll go ahead and do it.

## Related Tickets & Documents

[PANDA-1036](https://issues.redhat.com/browse/PANDA-1036)
Closes #271

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

Debugged & tested on `./run-local.sh` deployment. Ran unit tests and functional tests.