### PR TITLE
Back off CA validation on OpenSearch

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -54,8 +54,6 @@ jobs:
       with:
         image: backend
         context: backend
-        build-args: |
-          CA_CERT_PATH=${{ secrets.CA_CERT_PATH}}
         tags: latest ${{ github.sha }}
         containerfiles: |
           ./backend/backend.containerfile

--- a/.github/workflows/release-build-push.yaml
+++ b/.github/workflows/release-build-push.yaml
@@ -55,8 +55,6 @@ jobs:
       with:
         image: backend
         context: backend
-        build-args: |
-          CA_CERT_PATH=${{ secrets.CA_CERT_PATH}}
         tags: prod ${{ github.sha }}
         containerfiles: |
           ./backend/backend.containerfile

--- a/backend/app/services/crucible_svc.py
+++ b/backend/app/services/crucible_svc.py
@@ -726,7 +726,9 @@ class CrucibleService:
         self.auth = (self.user, self.password) if self.user or self.password else None
         self.url = self.cfg.get(configpath + ".url")
         self.versions = set()
-        self.elastic = AsyncOpenSearch(self.url, http_auth=self.auth)
+        self.elastic = AsyncOpenSearch(
+            self.url, verify_certs=False, http_auth=self.auth
+        )
         self.logger.info("Initializing CDM service to %s", self.url)
 
     async def detect_versions(self):

--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -39,9 +39,9 @@ class ElasticService:
             esUser = config.get(path + ".username")
             esPass = config.get(path + ".password")
         if esUser:
-            es = AsyncOpenSearch(url, http_auth=(esUser, esPass))
+            es = AsyncOpenSearch(url, verify_certs=False, http_auth=(esUser, esPass))
         else:
-            es = AsyncOpenSearch(url)
+            es = AsyncOpenSearch(url, verify_certs=False)
         return es, indice, index_prefix
 
     async def post(

--- a/backend/backend.containerfile
+++ b/backend/backend.containerfile
@@ -6,14 +6,6 @@ ENV POETRY_VIRTUALENVS_CREATE=false \
     XDG_CONFIG_HOME=/backend/.config \
     XDG_CACHE_HOME=/backend/.cache
 
-# We just want a "safe" file we can always copy with innocuous content if no
-# CA is specified.
-ARG CA_CERT_PATH=""
-
-# Add a CA certificate to the container trust store
-ADD ${CA_CERT_PATH} /etc/pki/ca-trust/source/anchors/
-RUN update-ca-trust
-
 # 1) Install system deps + Poetry globally (root)
 #    Installing Poetry globally ensures the binary is on /usr/local/bin
 #    and therefore available in both OpenShift (random UID) and Podman (root) environments

--- a/backend/tests/unit/test_search.py
+++ b/backend/tests/unit/test_search.py
@@ -135,7 +135,9 @@ class TestElasticService:
         )
 
         mock_es.assert_called_with(
-            "http://localhost:9200", http_auth=("testuser", "testpass")
+            "http://localhost:9200",
+            verify_certs=False,
+            http_auth=("testuser", "testpass"),
         )
         assert indice == "test-index"
         assert prefix == "test-"
@@ -149,7 +151,7 @@ class TestElasticService:
             mock_config_no_auth, "elasticsearch", "custom-index"
         )
 
-        mock_es.assert_called_with("http://localhost:9200")
+        mock_es.assert_called_with("http://localhost:9200", verify_certs=False)
         assert indice == "custom-index"
         assert prefix == ""
 

--- a/run-container.sh
+++ b/run-container.sh
@@ -11,6 +11,11 @@ BRANCH="$(git rev-parse --show-toplevel)"
 BACKEND="${BRANCH}/backend"
 FRONTEND="${BRANCH}/frontend"
 CPT_CONFIG=${CPT_CONFIG:-"${BACKEND}/ocpperf.toml"}
+if [ ! -f "${CPT_CONFIG}" ]; then
+    echo "Error: ${CPT_CONFIG} not found" >&2
+    echo "Please update the ${CPT_CONFIG} file to meet your needs." >&2
+    exit 1
+fi
 
 export CONTAINERS=()
 
@@ -26,16 +31,9 @@ cleanup () {
     fi
 }
 
-if [ -z "${CA_CERT_PATH}" ]; then
-    echo "CA_CERT_PATH is not set"
-    arg=""
-else
-    arg="--build-arg CA_CERT_PATH=${CA_CERT_PATH}"
-fi
-
 echo "Creating version"
 ( cd ${BACKEND}; poetry install ; poetry run scripts/version.py )
-podman build -f backend.containerfile ${arg} --tag backend "${BACKEND}"
+podman build -f backend.containerfile --tag backend "${BACKEND}"
 echo "Starting backend container"
 podman run -d --name="backend" -p 127.0.0.1:8000:8000 -v "${CPT_CONFIG}:/backend/ocpperf.toml:Z" localhost/backend
 CONTAINERS=( "backend" )

--- a/run-local.sh
+++ b/run-local.sh
@@ -22,7 +22,7 @@ FRONTEND=${TOP}/frontend
 CPT_CONFIG=${CPT_CONFIG:-"${BACKEND}/ocpperf.toml"}
 if [ ! -f "${CPT_CONFIG}" ]; then
     echo "Error: ${CPT_CONFIG} not found" >&2
-    echo "Please update the backend/ocpperf.toml file to meet your needs." >&2
+    echo "Please update the ${CPT_CONFIG} file to meet your needs." >&2
     exit 1
 fi
 

--- a/testing/pod_setup.sh
+++ b/testing/pod_setup.sh
@@ -63,7 +63,7 @@ podman pod create --name=${POD_NAME} ${PUBLISH}
 
 echo "Creating version"
 ( cd ${BACKEND}; poetry install; poetry install; poetry run scripts/version.py )
-podman build -f backend.containerfile --build-arg CA_CERT_PATH="" --tag backend "${BACKEND}"
+podman build -f backend.containerfile --tag backend "${BACKEND}"
 podman build -f frontend.containerfile --tag frontend "${FRONTEND}"
 podman build -f ${TESTING}/functional.containerfile --tag functional "${BRANCH}"
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This problem turned out to be a bit more difficult than I'd hoped, since we build our deployment containers on GitHub Actions with external runners which can't reach the internal Red Hat CA URL. Ultimately the solution would have to be grabbing and installing the CA bundle at container startup (e.g., in the entrypoint); but for now I'm going to declare (temporary) defeat and restore the `verify_certs=False`.

## Related Tickets & Documents

[PANDA-1005](https://issues.redhat.com/browse/PANDA-1005) Red Hat CA chain

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

The real problem is that it's difficult to test GitHub Actions outside the normal triggers, which means we don't see container build problems until merging onto `main`. And, in this case, a local test wouldn't really help since I can't reproduce the GitHub Action Runner environment enough to be sure it makes any difference.